### PR TITLE
Automatically mask credentials from build log

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/MaskingConsoleLogFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/MaskingConsoleLogFilter.java
@@ -1,0 +1,38 @@
+package com.datapipe.jenkins.vault;
+
+import hudson.console.ConsoleLogFilter;
+import hudson.console.LineTransformationOutputStream;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Created by tobiaslarscheid on 14.11.16.
+ */
+public class MaskingConsoleLogFilter extends ConsoleLogFilter implements Serializable{
+    final Run<?, ?> build;
+    private List<String> valuesToMask;
+
+
+    public MaskingConsoleLogFilter(final Run<?, ?> build, List<String> valuesToMask){
+        this.build= build;
+        this.valuesToMask = valuesToMask;
+    }
+
+    @Override
+    public OutputStream decorateLogger(AbstractBuild abstractBuild, final OutputStream logger) throws IOException, InterruptedException {
+        return new LineTransformationOutputStream() {
+            @Override protected void eol(byte[] b, int len) throws IOException {
+                String logEntry = new String(b, 0, len, build.getCharset().name());
+                for (String value : valuesToMask) {
+                    logEntry = logEntry.replace(value, "****");
+                }
+                logger.write(logEntry.getBytes(build.getCharset().name()));
+            }
+        };
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/MaskingConsoleLogFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/MaskingConsoleLogFilter.java
@@ -3,35 +3,34 @@ package com.datapipe.jenkins.vault;
 import hudson.console.ConsoleLogFilter;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.AbstractBuild;
-import hudson.model.Run;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.List;
 
-/**
- * Created by tobiaslarscheid on 14.11.16.
- */
-public class MaskingConsoleLogFilter extends ConsoleLogFilter implements Serializable{
-    final Run<?, ?> build;
+public class MaskingConsoleLogFilter extends ConsoleLogFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String charsetName;
     private List<String> valuesToMask;
 
 
-    public MaskingConsoleLogFilter(final Run<?, ?> build, List<String> valuesToMask){
-        this.build= build;
+    public MaskingConsoleLogFilter(final String charsetName, List<String> valuesToMask) {
+        this.charsetName = charsetName;
         this.valuesToMask = valuesToMask;
     }
 
     @Override
     public OutputStream decorateLogger(AbstractBuild abstractBuild, final OutputStream logger) throws IOException, InterruptedException {
         return new LineTransformationOutputStream() {
-            @Override protected void eol(byte[] b, int len) throws IOException {
-                String logEntry = new String(b, 0, len, build.getCharset().name());
+            @Override
+            protected void eol(byte[] b, int len) throws IOException {
+                String logEntry = new String(b, 0, len, charsetName);
                 for (String value : valuesToMask) {
                     logEntry = logEntry.replace(value, "****");
                 }
-                logger.write(logEntry.getBytes(build.getCharset().name()));
+                logger.write(logEntry.getBytes(charsetName));
             }
         };
     }

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -162,7 +162,7 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
 
   @Override
   public ConsoleLogFilter createLoggerDecorator(@Nonnull final Run<?, ?> build) {
-    return new MaskingConsoleLogFilter(build, valuesToMask);
+    return new MaskingConsoleLogFilter(build.getCharset().name(), valuesToMask);
   }
 
   /**

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -28,7 +28,6 @@ import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import hudson.*;
 import hudson.console.ConsoleLogFilter;
-import hudson.console.LineTransformationOutputStream;
 import hudson.model.*;
 import hudson.tasks.BuildWrapper;
 import hudson.util.Secret;
@@ -42,13 +41,10 @@ import org.kohsuke.stapler.StaplerRequest;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Sample {@link BuildWrapper}.

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -166,20 +166,7 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
 
   @Override
   public ConsoleLogFilter createLoggerDecorator(@Nonnull final Run<?, ?> build) {
-    return new ConsoleLogFilter() {
-      @Override
-      public OutputStream decorateLogger(AbstractBuild abstractBuild, final OutputStream logger) throws IOException, InterruptedException {
-        return new LineTransformationOutputStream() {
-          @Override protected void eol(byte[] b, int len) throws IOException {
-            String logEntry = new String(b, 0, len, build.getCharset().name());
-            for (String value : valuesToMask) {
-             logEntry = logEntry.replace(value, "****");
-            }
-            logger.write(logEntry.getBytes(build.getCharset().name()));
-          }
-        };
-      }
-    };
+    return new MaskingConsoleLogFilter(build, valuesToMask);
   }
 
   /**

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -164,6 +164,24 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
     }
   }
 
+  @Override
+  public ConsoleLogFilter createLoggerDecorator(@Nonnull final Run<?, ?> build) {
+    return new ConsoleLogFilter() {
+      @Override
+      public OutputStream decorateLogger(AbstractBuild abstractBuild, final OutputStream logger) throws IOException, InterruptedException {
+        return new LineTransformationOutputStream() {
+          @Override protected void eol(byte[] b, int len) throws IOException {
+            String logEntry = new String(b, 0, len, build.getCharset().name());
+            for (String value : valuesToMask) {
+             logEntry.replace(value, "****");
+            }
+            logger.write(logEntry.getBytes(build.getCharset().name()));
+          }
+        };
+      }
+    };
+  }
+
   /**
    * Descriptor for {@link VaultBuildWrapper}. Used as a singleton. The class is marked as public so
    * that it can be accessed from views.

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -173,7 +173,7 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
           @Override protected void eol(byte[] b, int len) throws IOException {
             String logEntry = new String(b, 0, len, build.getCharset().name());
             for (String value : valuesToMask) {
-             logEntry.replace(value, "****");
+             logEntry = logEntry.replace(value, "****");
             }
             logger.write(logEntry.getBytes(build.getCharset().name()));
           }


### PR DESCRIPTION
The vault plugin should mask any secrets obtained through it from the build login [see JIRA Issue](https://issues.jenkins-ci.org/browse/JENKINS-39383). This is already done by the regular jenkins credentials binding plugin - implementation is therefore heavily inspired by how it is done [there](https://github.com/jenkinsci/credentials-binding-plugin/blob/master/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java#L151).

**Important:** I was not able to run the tests, as it requires a properly initialized local Vault Instance. I would propose to rather mock the real Vault Instance for the Unit Tests to make them not only faster but also easier to run for contributors. Also, my change is actually breaking the test as the test asserts echo'ed output in the log.