### PR TITLE
Bump Vault Java Driver to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>com.bettercloud</groupId>
 			<artifactId>vault-java-driver</artifactId>
-			<version>1.1.0</version>
+			<version>2.0.0</version>
 		</dependency>
 	</dependencies>
 	<reporting>


### PR DESCRIPTION
In our following work we want to enhance this plugin to use the new AppRole backend.

* In 2.0.0 the AppRole backend (which is way more suitable for Jenkins), was enabled.