### PR TITLE
Changed Vault login strategy to AppRole instead of Token.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>com.bettercloud</groupId>
 			<artifactId>vault-java-driver</artifactId>
-			<version>1.1.0</version>
+			<version>2.0.0</version>
 		</dependency>
 	</dependencies>
 	<reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<jenkins.version>1.625.3</jenkins.version>
 		<java.level>7</java.level>
-		<jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+		<jenkins-test-harness.version>2.19</jenkins-test-harness.version>
 	</properties>
 
 	<name>HashiCorp Vault Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,101 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>2.17</version>
-        <relativePath/>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.jenkins-ci.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>2.17</version>
+		<relativePath />
+	</parent>
 
-    <groupId>com.datapipe.jenkins.plugins</groupId>
-    <artifactId>hashicorp-vault-plugin</artifactId>
-    <version>1.4-SNAPSHOT</version>
-    <packaging>hpi</packaging>
+	<groupId>com.datapipe.jenkins.plugins</groupId>
+	<artifactId>hashicorp-vault-plugin</artifactId>
+	<version>1.4-SNAPSHOT</version>
+	<packaging>hpi</packaging>
 
-    <properties>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
-        <jenkins-test-harness.version>2.19</jenkins-test-harness.version>
-    </properties>
+	<properties>
+		<jenkins.version>1.625.3</jenkins.version>
+		<java.level>7</java.level>
+		<jenkins-test-harness.version>2.19</jenkins-test-harness.version>
+	</properties>
 
-    <name>HashiCorp Vault Plugin</name>
-    <description>Build Wrapper for reading secrets in a HashiCorp Vault</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/HashiCorp+Vault+Plugin</url>
+	<name>HashiCorp Vault Plugin</name>
+	<description>Build Wrapper for reading secrets in a HashiCorp Vault</description>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/HashiCorp+Vault+Plugin</url>
 
-    <organization>
-        <name>Datapipe, Inc.</name>
-        <url>https://www.datapipe.com</url>
-    </organization>
+	<organization>
+		<name>Datapipe, Inc.</name>
+		<url>https://www.datapipe.com</url>
+	</organization>
 
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
+	<licenses>
+		<license>
+			<name>MIT License</name>
+			<url>http://opensource.org/licenses/MIT</url>
+		</license>
+	</licenses>
 
-    <developers>
-        <developer>
-            <id>ptierno</id>
-            <name>Peter A. Tierno</name>
-            <email>ptierno@datapipe.com</email>
-        </developer>
-    </developers>
+	<developers>
+		<developer>
+			<id>ptierno</id>
+			<name>Peter A. Tierno</name>
+			<email>ptierno@datapipe.com</email>
+		</developer>
+	</developers>
 
-    <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
-        <url>http://github.com/jenkinsci/${project.artifactId}</url>
-        <tag>hashicorp-vault-plugin-1.3</tag>
-    </scm>
+	<scm>
+		<connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
+		<url>http://github.com/jenkinsci/${project.artifactId}</url>
+	  <tag>hashicorp-vault-plugin-1.3</tag>
+  </scm>
 
 
-    <!--
-    <distributionManagement>
-      <repository>
-        <id>maven.jenkins-ci.org</id>
-        <url>https://repo.jenkins-ci.org/releases/</url>
-      </repository>
-      <snapshotRepository>
-        <id>maven.jenkins-ci.org</id>
-        <url>https://repo.jenkins-ci.org/snapshots/</url>
-      </snapshotRepository>
-    </distributionManagement>
-    -->
+  <!--
+  <distributionManagement>
+    <repository>
+      <id>maven.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
+    </repository>
+    <snapshotRepository>
+      <id>maven.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+  -->
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>https://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>https://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
+	<dependencies>
+		<dependency>
+		    <groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>credentials</artifactId>
             <version>2.1.13</version>
-        </dependency>
-        <dependency>
-            <groupId>com.bettercloud</groupId>
-            <artifactId>vault-java-driver</artifactId>
-            <version>2.0.0</version>
-        </dependency>
-    </dependencies>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.19.1</version>
-            </plugin>
-        </plugins>
-    </reporting>
+		</dependency>
+		<dependency>
+			<groupId>com.bettercloud</groupId>
+			<artifactId>vault-java-driver</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+	</dependencies>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>2.19.1</version>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,101 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.jenkins-ci.plugins</groupId>
-		<artifactId>plugin</artifactId>
-		<version>2.17</version>
-		<relativePath />
-	</parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>2.17</version>
+        <relativePath/>
+    </parent>
 
-	<groupId>com.datapipe.jenkins.plugins</groupId>
-	<artifactId>hashicorp-vault-plugin</artifactId>
-	<version>1.4-SNAPSHOT</version>
-	<packaging>hpi</packaging>
+    <groupId>com.datapipe.jenkins.plugins</groupId>
+    <artifactId>hashicorp-vault-plugin</artifactId>
+    <version>1.4-SNAPSHOT</version>
+    <packaging>hpi</packaging>
 
-	<properties>
-		<jenkins.version>1.625.3</jenkins.version>
-		<java.level>7</java.level>
-		<jenkins-test-harness.version>2.19</jenkins-test-harness.version>
-	</properties>
+    <properties>
+        <jenkins.version>1.625.3</jenkins.version>
+        <java.level>7</java.level>
+        <jenkins-test-harness.version>2.19</jenkins-test-harness.version>
+    </properties>
 
-	<name>HashiCorp Vault Plugin</name>
-	<description>Build Wrapper for reading secrets in a HashiCorp Vault</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/HashiCorp+Vault+Plugin</url>
+    <name>HashiCorp Vault Plugin</name>
+    <description>Build Wrapper for reading secrets in a HashiCorp Vault</description>
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/HashiCorp+Vault+Plugin</url>
 
-	<organization>
-		<name>Datapipe, Inc.</name>
-		<url>https://www.datapipe.com</url>
-	</organization>
+    <organization>
+        <name>Datapipe, Inc.</name>
+        <url>https://www.datapipe.com</url>
+    </organization>
 
-	<licenses>
-		<license>
-			<name>MIT License</name>
-			<url>http://opensource.org/licenses/MIT</url>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<id>ptierno</id>
-			<name>Peter A. Tierno</name>
-			<email>ptierno@datapipe.com</email>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>ptierno</id>
+            <name>Peter A. Tierno</name>
+            <email>ptierno@datapipe.com</email>
+        </developer>
+    </developers>
 
-	<scm>
-		<connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
-		<url>http://github.com/jenkinsci/${project.artifactId}</url>
-	  <tag>hashicorp-vault-plugin-1.3</tag>
-  </scm>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
+        <url>http://github.com/jenkinsci/${project.artifactId}</url>
+        <tag>hashicorp-vault-plugin-1.3</tag>
+    </scm>
 
 
-  <!--
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/releases/</url>
-    </repository>
-    <snapshotRepository>
-      <id>maven.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
-  -->
+    <!--
+    <distributionManagement>
+      <repository>
+        <id>maven.jenkins-ci.org</id>
+        <url>https://repo.jenkins-ci.org/releases/</url>
+      </repository>
+      <snapshotRepository>
+        <id>maven.jenkins-ci.org</id>
+        <url>https://repo.jenkins-ci.org/snapshots/</url>
+      </snapshotRepository>
+    </distributionManagement>
+    -->
 
-	<repositories>
-		<repository>
-			<id>repo.jenkins-ci.org</id>
-			<url>https://repo.jenkins-ci.org/public/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>repo.jenkins-ci.org</id>
-			<url>https://repo.jenkins-ci.org/public/</url>
-		</pluginRepository>
-	</pluginRepositories>
-	<dependencies>
-		<!-- possibly adding this
-		<dependency>
-		    <groupId>org.jenkins-ci.plugins</groupId> 
-			<artifactId>credentials</artifactId> <version>1.9.4</version>
-		</dependency>
-		-->
-		<dependency>
-			<groupId>com.bettercloud</groupId>
-			<artifactId>vault-java-driver</artifactId>
-			<version>2.0.0</version>
-		</dependency>
-	</dependencies>
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.19.1</version>
-			</plugin>
-		</plugins>
-	</reporting>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.13</version>
+        </dependency>
+        <dependency>
+            <groupId>com.bettercloud</groupId>
+            <artifactId>vault-java-driver</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+    </dependencies>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.19.1</version>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -98,7 +98,7 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
 
   @DataBoundSetter
   public void setSecretId(String secretId) {
-      this.secretId = Secret.fromString(secretId);
+    this.secretId = Secret.fromString(secretId);
   }
 
   private Secret getSecretId() {
@@ -231,21 +231,21 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
       Object secretId = formData.getString("secretId");
 
       if (!JSONNull.getInstance().equals(vaultUrl)) {
-          this.vaultUrl = (String) vaultUrl;
+        this.vaultUrl = (String) vaultUrl;
       } else {
-          this.vaultUrl = null;
+        this.vaultUrl = null;
       }
 
       if (!JSONNull.getInstance().equals(roleId)) {
-          this.roleId = (String) roleId;
+        this.roleId = (String) roleId;
       } else {
-          this.roleId = null;
+        this.roleId = null;
       }
 
       if (!JSONNull.getInstance().equals(secretId)) {
-          this.secretId = Secret.fromString((String) secretId);
+        this.secretId = Secret.fromString((String) secretId);
       } else {
-          this.secretId = null;
+        this.secretId = null;
       }
 
       save();

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredential.java
@@ -1,0 +1,23 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import javax.annotation.Nonnull;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+
+import hudson.util.Secret;
+
+@NameWith(VaultTokenCredential.NameProvider.class)
+public interface VaultTokenCredential extends StandardCredentials {
+    String getRoleId();
+    Secret getSecretId();
+
+   public static class NameProvider extends CredentialsNameProvider<VaultTokenCredential> {
+
+      @Nonnull
+      public String getName(@Nonnull VaultTokenCredential credentials) {
+         return credentials.getDescription();
+      }
+   }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialImpl.java
@@ -1,0 +1,43 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.datapipe.jenkins.vault.credentials.VaultTokenCredential;
+import hudson.Extension;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+public class VaultTokenCredentialImpl extends BaseStandardCredentials implements VaultTokenCredential{
+    private final @Nonnull Secret secretId;
+
+    private final @Nonnull String roleId;
+
+    @DataBoundConstructor
+    public VaultTokenCredentialImpl(@CheckForNull CredentialsScope scope, @CheckForNull String id, @CheckForNull String description, @Nonnull String roleId, @Nonnull Secret secretId) {
+        super(scope, id, description);
+        this.secretId = secretId;
+        this.roleId = roleId;
+    }
+
+    @Override
+    public String getRoleId() {
+        return roleId;
+    }
+
+    @Override
+    public Secret getSecretId() {
+        return secretId;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override public String getDisplayName() {
+            return "Vault Token Credential";
+        }
+
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/exception/VaultPluginException.java
+++ b/src/main/java/com/datapipe/jenkins/vault/exception/VaultPluginException.java
@@ -1,0 +1,11 @@
+package com.datapipe.jenkins.vault.exception;
+
+public class VaultPluginException extends  RuntimeException {
+    public VaultPluginException(String message) {
+        super(message);
+    }
+
+    public VaultPluginException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
@@ -9,7 +9,7 @@
           </f:entry>
         </f:optionalBlock>
         <f:optionalBlock name="roleIdOverride" title="Override Credentials?">
-          <f:entry title="Authentication Token Credential ID" field="authTokenCredentialId">
+          <f:entry title="App Role Credential" field="appRoleCredentialId">
             <c:select />
           </f:entry>
         </f:optionalBlock>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
@@ -1,7 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Vault Plugin">
-
     <f:block>
       <table>
         <f:optionalBlock name="urlOverride" title="Override Vault URL?">
@@ -9,10 +8,15 @@
             <f:textbox />
           </f:entry>
         </f:optionalBlock>
-        <f:optionalBlock name="tokenOverride" title="Override Authentication Token?">
-          <f:entry title="Authentication Token" field="authToken">
-            <f:password />
-          </f:entry>
+        <f:optionalBlock name="roleIdOverride" title="Override Role ID?">
+           <f:entry title="App-Role: Role-ID" field="roleId">
+             <f:textbox />
+           </f:entry>
+        </f:optionalBlock>
+        <f:optionalBlock name="secretIdOverride" title="Override Secret ID?">
+           <f:entry title="App-Role: Secret-ID" field="secretId">
+             <f:password />
+           </f:entry>
         </f:optionalBlock>
       </table>
     </f:block>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:section title="Vault Plugin">
     <f:block>
       <table>
@@ -8,15 +8,10 @@
             <f:textbox />
           </f:entry>
         </f:optionalBlock>
-        <f:optionalBlock name="roleIdOverride" title="Override Role ID?">
-           <f:entry title="App-Role: Role-ID" field="roleId">
-             <f:textbox />
-           </f:entry>
-        </f:optionalBlock>
-        <f:optionalBlock name="secretIdOverride" title="Override Secret ID?">
-           <f:entry title="App-Role: Secret-ID" field="secretId">
-             <f:password />
-           </f:entry>
+        <f:optionalBlock name="roleIdOverride" title="Override Credentials?">
+          <f:entry title="Authentication Token Credential ID" field="authTokenCredentialId">
+            <c:select />
+          </f:entry>
         </f:optionalBlock>
       </table>
     </f:block>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/global.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/global.jelly
@@ -1,17 +1,13 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:section title="Vault Plugin">
 
     <f:entry title="Vault URL" field="vaultUrl">
       <f:textbox />
     </f:entry>
     
-    <f:entry title="App-Role: Role-ID" field="roleId">
-      <f:textbox />
-    </f:entry>
-
-     <f:entry title="App-Role: Secret-ID" field="secretId">
-      <f:password />
+    <f:entry title="Authentication Token Credential ID" field="authTokenCredentialId">
+      <c:select />
     </f:entry>
 
   </f:section>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/global.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/global.jelly
@@ -6,7 +6,7 @@
       <f:textbox />
     </f:entry>
     
-    <f:entry title="Authentication Token Credential ID" field="authTokenCredentialId">
+    <f:entry title="App Role Credential" field="appRoleCredentialId">
       <c:select />
     </f:entry>
 

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/global.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/global.jelly
@@ -6,7 +6,11 @@
       <f:textbox />
     </f:entry>
     
-    <f:entry title="Authentication token" field="authToken">
+    <f:entry title="App-Role: Role-ID" field="roleId">
+      <f:textbox />
+    </f:entry>
+
+     <f:entry title="App-Role: Secret-ID" field="secretId">
       <f:password />
     </f:entry>
 

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-authToken.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-authToken.html
@@ -1,3 +1,0 @@
-<div>
-  The token to use to authenticate to the vault server.
-</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-roleId.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-roleId.html
@@ -1,0 +1,3 @@
+<div>
+  The role ID you get from your Vault server. See https://www.vaultproject.io/docs/auth/approle.html for details. <br />
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-secretId.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-secretId.html
@@ -1,0 +1,4 @@
+<div>
+    The secret ID you get from your Vault server. See https://www.vaultproject.io/docs/auth/approle.html for details. <br />
+    You may want to make sure that your secret ID has no TTL and is bound to a specific CIDR / Network. Please refer to the docs for more information.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-vaultUrl.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/help-vaultUrl.html
@@ -1,3 +1,0 @@
-<div>
-  The url of the vault server (ie. http://127.0.0.1:8200).
-</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialImpl/credentials.jelly
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-    <f:entry title="RoleID">
+    <f:entry title="Role ID">
         <f:textbox field="roleId" name="roleId" />
     </f:entry>
     <f:entry title="Secret ID">

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialImpl/credentials.jelly
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <f:entry title="RoleID">
+        <f:textbox field="roleId" name="roleId" />
+    </f:entry>
+    <f:entry title="Secret ID">
+        <f:password field="secretId" name="secretId" />
+    </f:entry>
+    <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>


### PR DESCRIPTION
AppRole is the far superior auth backend. It is way more suitable for applications like Jenkins.
We now need to supply a RoleID and an SecretID. Based on this credentials we can obtain a token from Vault.
This token is only valid for a couple of minutes then.

We can restrict the RoleID/SecretID-tuple to have a ttl (and all this other stuff). What I recommend, though, is restricting the usage of the AppRole backend via `bound_cidr_list`. This way the RoleID/SecretID-tuple can only be exchanged for a valid access token when the request comes from a certain IP range.

It is based on #3.