### PR TITLE
Filter nulls from secret list

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/log/MaskingConsoleLogFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/log/MaskingConsoleLogFilter.java
@@ -59,7 +59,10 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
      */
     public static String getPatternStringForSecrets(Collection<String> secrets) {
         StringBuilder b = new StringBuilder();
-        List<String> sortedByLength = new ArrayList<String>(secrets);
+        List<String> sortedByLength = new ArrayList<String>(secrets.size());
+        for (String secret : secrets) {
+        	if (secret != null) sortedByLength.add(secret);
+        }
         Collections.sort(sortedByLength, new Comparator<String>() {
             @Override
             public int compare(String o1, String o2) {


### PR DESCRIPTION
Our jobs are failing (and producing, as expected, no output) with:

```
Executor threw an exception
java.lang.NullPointerException
	at com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter$2.compare(MaskingConsoleLogFilter.java:66)
	at com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter$2.compare(MaskingConsoleLogFilter.java:63)
	at java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.util.TimSort.sort(TimSort.java:220)
	at java.util.Arrays.sort(Arrays.java:1512)
	at java.util.ArrayList.sort(ArrayList.java:1454)
	at java.util.Collections.sort(Collections.java:175)
	at com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter.getPatternStringForSecrets(MaskingConsoleLogFilter.java:63)
	at com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter$1.eol(MaskingConsoleLogFilter.java:38)
	at hudson.console.LineTransformationOutputStream.eol(LineTransformationOutputStream.java:60)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:56)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:74)
	at java.io.PrintStream.write(PrintStream.java:480)
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221)
	at sun.nio.cs.StreamEncoder.implFlushBuffer(StreamEncoder.java:291)
	at sun.nio.cs.StreamEncoder.flushBuffer(StreamEncoder.java:104)
	at java.io.OutputStreamWriter.flushBuffer(OutputStreamWriter.java:185)
	at java.io.PrintStream.newLine(PrintStream.java:546)
	at java.io.PrintStream.println(PrintStream.java:807)
	at hudson.model.StreamBuildListener.finished(StreamBuildListener.java:80)
	at hudson.model.Run.execute(Run.java:1791)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:419)
```