### PR TITLE
Update pom.xml for vault-java-driver 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>3.1.0</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Updated BetterCloud's vault-java-driver from 3.1.0 to 4.0.0.  The latest driver now supports Hashicorp Vault 1.0 and important features: KV v2 and namespaces.

I ran mvn test against this after updating to 4.0.0, and there were no errors.