### PR TITLE
JENKINS-52895

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -160,7 +160,7 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
                         context.env(envKey, values.get(value.getVaultKey()));
                     }
                 }
-            }catch (VaultPluginException ex) {
+            } catch (VaultPluginException ex) {
                 VaultException e = (VaultException) ex.getCause();
                 if (e.getHttpStatusCode() == 404 && !configuration.isFailIfNotFound())
                     logger.println("Vault credentials not found " + vaultSecret.getPath());

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
@@ -51,22 +51,14 @@ public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
   private static final String NO_PREFIX = "";
 
   private String path;
-  private String envPrefix;
+  private String envPrefix = NO_PREFIX;
   private Integer engineVersion;
   private List<VaultSecretValue> secretValues;
 
-  public VaultSecret(String path, List<VaultSecretValue> secretValues) {
-    this(path, secretValues, NO_PREFIX);
-  }
-
   @DataBoundConstructor
-  public VaultSecret(String path, List<VaultSecretValue> secretValues, String envPrefix) {
+  public VaultSecret(String path, List<VaultSecretValue> secretValues) {
     this.path = path;
     this.secretValues = secretValues;
-    if (envPrefix != null) {
-      this.envPrefix = envPrefix;
-    }
-    else this.envPrefix = NO_PREFIX;
   }
 
   @DataBoundSetter
@@ -88,6 +80,13 @@ public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
 
   public String getEnvPrefix() {
     return envPrefix;
+  }
+
+  @DataBoundSetter
+  public void setEnvPrefix(String envPrefix) {
+    if (envPrefix != null) {
+      this.envPrefix = envPrefix;
+    }
   }
 
   @Extension

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
@@ -55,7 +55,6 @@ public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
   private Integer engineVersion;
   private List<VaultSecretValue> secretValues;
 
-//  @DataBoundConstructor
   public VaultSecret(String path, List<VaultSecretValue> secretValues) {
     this(path, secretValues, NO_PREFIX);
   }

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
@@ -42,14 +42,32 @@ import java.util.List;
  */
 public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
 
+  /**
+   * Default prefix is used to differentiate values having the same keys across
+   * multiple Vault paths. In this way, the different secrets can both be stored
+   * in Jenkins' environment under different names.
+   * The default remains to NOT include a prefix so as to retain current behaviour.
+   */
+  private static final String NO_PREFIX = "";
+
   private String path;
+  private String envPrefix;
   private Integer engineVersion;
   private List<VaultSecretValue> secretValues;
 
-  @DataBoundConstructor
+//  @DataBoundConstructor
   public VaultSecret(String path, List<VaultSecretValue> secretValues) {
+    this(path, secretValues, NO_PREFIX);
+  }
+
+  @DataBoundConstructor
+  public VaultSecret(String path, List<VaultSecretValue> secretValues, String envPrefix) {
     this.path = path;
     this.secretValues = secretValues;
+    if (envPrefix != null) {
+      this.envPrefix = envPrefix;
+    }
+    else this.envPrefix = NO_PREFIX;
   }
 
   @DataBoundSetter
@@ -67,6 +85,10 @@ public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
 
   public List<VaultSecretValue> getSecretValues() {
     return this.secretValues;
+  }
+
+  public String getEnvPrefix() {
+    return envPrefix;
   }
 
   @Extension

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecret/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecret/config.jelly
@@ -21,4 +21,8 @@
     </f:entry>
   </f:advanced>
 
+  <f:entry title="Environment Variable Prefix" field="envPrefix">
+    <f:textbox />
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecret/help-envPrefix.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecret/help-envPrefix.html
@@ -1,0 +1,3 @@
+<div>
+    A prefix that is applied to all environment variables when retrieving secrets from Vault. No prefix is applied by default. This can be useful when differentiating secrets in multiple paths having the same name.
+</div>

--- a/src/test/java/com/datapipe/jenkins/vault/VaultBuildWrapperWithMockAccessor.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultBuildWrapperWithMockAccessor.java
@@ -49,6 +49,7 @@ public class VaultBuildWrapperWithMockAccessor extends VaultBuildWrapper {
                 }
                 Map<String, String> returnValue = new HashMap<>();
                 returnValue.put("key1", "some-secret");
+                returnValue.put("key2", "another-secret");
                 LogicalResponse resp = mock(LogicalResponse.class);
                 when(resp.getData()).thenReturn(returnValue);
                 return resp;


### PR DESCRIPTION
Jenkins Vault Plugin now pulls in all secrets if none are specified. Keys can now be prefixed before being placed in Jenkins' environment map to eliminate conflicts of secret names across multiple Vault paths.