### PR TITLE
Improvements

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -138,10 +138,11 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
                 responses.add(response);
                 Map<String, String> values = response.getData();
                 for (VaultSecretValue value : vaultSecret.getSecretValues()) {
-                    if (values.get(value.getVaultKey()) == null || values.get(value.getVaultKey()).trim().isEmpty())
+                    String secret = values.get(value.getVaultKey());
+                    if (StringUtils.isBlank(secret))
                         throw new IllegalArgumentException("Vault Secret " + value.getVaultKey() + " at " + vaultSecret.getPath() + " is either null or empty. Please check the Secret in Vault.");
-                    valuesToMask.add(values.get(value.getVaultKey()));
-                    context.env(value.getEnvVar(), values.get(value.getVaultKey()));
+                    valuesToMask.add(secret);
+                    context.env(value.getEnvVar(), secret);
                 }
             }catch (VaultPluginException ex) {
                 VaultException e = (VaultException) ex.getCause();

--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -41,6 +41,7 @@ import com.datapipe.jenkins.vault.model.VaultSecret;
 import com.datapipe.jenkins.vault.model.VaultSecretValue;
 
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -193,6 +194,7 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
      * that it can be accessed from views.
      */
     @Extension
+    @Symbol("withVault")
     public static final class DescriptorImpl extends BuildWrapperDescriptor {
         public DescriptorImpl() {
             super(VaultBuildWrapper.class);

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
@@ -21,20 +21,23 @@ import hudson.model.Item;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 
+import static hudson.Util.fixEmptyAndTrim;
+
 public class VaultConfiguration extends AbstractDescribableImpl<VaultConfiguration> implements Serializable {
     private String vaultUrl;
 
     private String vaultCredentialId;
 
-    private boolean failIfNotFound = true;
+    private boolean failIfNotFound = DescriptorImpl.DEFAULT_FAIL_NOT_FOUND;
 
-    private boolean skipSslVerification = false;
+    private boolean skipSslVerification = DescriptorImpl.DEFAULT_SKIP_SSL_VERIFICATION;
 
+    @DataBoundConstructor
     public VaultConfiguration() {
         // no args constructor
     }
 
-    @DataBoundConstructor
+    @Deprecated
     public VaultConfiguration(String vaultUrl, String vaultCredentialId, boolean failIfNotFound) {
         this.vaultUrl = normalizeUrl(vaultUrl);
         this.vaultCredentialId = vaultCredentialId;
@@ -45,6 +48,7 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         this.vaultUrl = toCopy.getVaultUrl();
         this.vaultCredentialId = toCopy.getVaultCredentialId();
         this.failIfNotFound = toCopy.failIfNotFound;
+        this.skipSslVerification = toCopy.skipSslVerification;
     }
 
     public VaultConfiguration mergeWithParent(VaultConfiguration parent) {
@@ -72,12 +76,12 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
 
     @DataBoundSetter
     public void setVaultUrl(String vaultUrl) {
-        this.vaultUrl = normalizeUrl(vaultUrl);
+        this.vaultUrl = normalizeUrl(fixEmptyAndTrim(vaultUrl));
     }
 
     @DataBoundSetter
     public void setVaultCredentialId(String vaultCredentialId) {
-        this.vaultCredentialId = vaultCredentialId;
+        this.vaultCredentialId = fixEmptyAndTrim(vaultCredentialId);
     }
 
     public boolean isFailIfNotFound() {
@@ -93,12 +97,18 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         return skipSslVerification;
     }
 
+    @DataBoundSetter
     public void setSkipSslVerification(boolean skipSslVerification) {
         this.skipSslVerification = skipSslVerification;
     }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<VaultConfiguration> {
+
+        public static final boolean DEFAULT_FAIL_NOT_FOUND = true;
+
+        public static final boolean DEFAULT_SKIP_SSL_VERIFICATION = false;
+
         @Override
         public String getDisplayName() {
             return "Vault Configuration";

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
@@ -43,7 +43,7 @@ import java.util.List;
 public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
 
   private String path;
-  private Integer engineVersion;
+  private Integer engineVersion = DescriptorImpl.DEFAULT_ENGINE_VERSION;
   private List<VaultSecretValue> secretValues;
 
   @DataBoundConstructor
@@ -72,29 +72,18 @@ public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
   @Extension
   public static final class DescriptorImpl extends Descriptor<VaultSecret> {
 
-    private Integer engineVersion;
-
-    public Integer getEngineVersion() {
-      return this.engineVersion;
-    }
+    public static final int DEFAULT_ENGINE_VERSION = 2;
 
     @Override
     public String getDisplayName() {
       return "Vault Secret";
     }
 
-    @Override
-    public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-      this.engineVersion = Integer.parseInt(formData.getString("engineVersion"));
-
-      save();
-      return false;
-    }
-
+    @SuppressWarnings("unused") // used by stapler
     public ListBoxModel doFillEngineVersionItems() {
       return new ListBoxModel(
-              new Option("2", "2"),
-              new Option("1", "1")
+          new Option("1", "1"),
+          new Option("2", "2")
       );
     }
 

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecret.java
@@ -28,12 +28,12 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.ListBoxModel;
 import hudson.util.ListBoxModel.Option;
-import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.List;
+
+import static hudson.Util.fixEmptyAndTrim;
 
 /**
  * Represents a Vault secret.
@@ -48,7 +48,7 @@ public class VaultSecret extends AbstractDescribableImpl<VaultSecret> {
 
   @DataBoundConstructor
   public VaultSecret(String path, List<VaultSecretValue> secretValues) {
-    this.path = path;
+    this.path = fixEmptyAndTrim(path);
     this.secretValues = secretValues;
   }
 

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -23,11 +23,16 @@
  */
 package com.datapipe.jenkins.vault.model;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import static hudson.Util.fixEmptyAndTrim;
 
 /**
  * @author Peter Tierno {@literal <}ptierno{@literal @}datapipe.com{@literal >}
@@ -36,20 +41,34 @@ public class VaultSecretValue
     extends AbstractDescribableImpl<VaultSecretValue> {
 
   private String envVar;
-  private String vaultKey;
+  private final String vaultKey;
 
-  @DataBoundConstructor
-  public VaultSecretValue(String envVar, String vaultKey) {
-    this.envVar = envVar;
-    this.vaultKey = vaultKey;
+  @Deprecated
+  public VaultSecretValue(String envVar, @NonNull String vaultKey) {
+    this.envVar = fixEmptyAndTrim(envVar);
+    this.vaultKey = fixEmptyAndTrim(vaultKey);
   }
 
+  @DataBoundConstructor
+  public VaultSecretValue(@NonNull String vaultKey) {
+    this.vaultKey = fixEmptyAndTrim(vaultKey);
+  }
+
+  @DataBoundSetter
+  public void setEnvVar(String envVar) {
+    this.envVar = envVar;
+  }
+
+  /**
+   *
+   * @return envVar if value is not empty otherwise return vaultKey
+   */
   public String getEnvVar() {
-    return this.envVar;
+    return StringUtils.isEmpty(envVar) ? vaultKey : envVar;
   }
 
   public String getVaultKey() {
-    return this.vaultKey;
+    return vaultKey;
   }
 
   @Extension

--- a/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/VaultBuildWrapper/config.jelly
@@ -1,9 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="Vault Plugin">
-        <f:property field="configuration" header="Vault Configuration" />
+        <f:property field="configuration" />
     </f:section>
     <f:entry>
-        <f:repeatableProperty field="vaultSecrets" minimum="0" header="Vault Secret" add="Add a vault secret"></f:repeatableProperty>
+        <f:repeatableProperty field="vaultSecrets" minimum="0" header="Vault Secret"
+          add="Add a vault secret"/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/FolderVaultConfiguration/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/FolderVaultConfiguration/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="Vault Plugin">
-        <f:property field="configuration" header="Vault Configuration"></f:property>
+        <f:property field="configuration" />
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/GlobalVaultConfiguration/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/GlobalVaultConfiguration/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:section title="Vault Plugin">
-        <f:property field="configuration" header="Vault Configuration" />
+        <f:property field="configuration" />
     </f:section>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
@@ -4,10 +4,15 @@
     <f:entry title="Vault URL">
         <f:textbox field="vaultUrl" name="vaultUrl"/>
     </f:entry>
-    <f:entry title="Vault Credential" field="vaultCredentialId" name="vaultCredentialId">
+    <f:entry title="Vault Credential" field="vaultCredentialId">
         <c:select/>
     </f:entry>
-    <f:entry title="Fail if path is not found" field="failIfNotFound" name="failIfNotFound">
-        <f:checkbox/>
-    </f:entry>
+    <f:advanced>
+        <f:entry title="Fail if path is not found" field="failIfNotFound">
+            <f:checkbox default="${descriptor.DEFAULT_FAIL_NOT_FOUND}"/>
+        </f:entry>
+        <f:entry title="Skip SSL verification" field="skipSslVerification">
+            <f:checkbox default="${descriptor.DEFAULT_SKIP_SSL_VERIFICATION}"/>
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecret/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecret/config.jelly
@@ -6,7 +6,7 @@
   </f:entry>
 
   <f:entry>
-    <f:repeatableProperty field="secretValues" minimum="1" add="Add a key/value pair"></f:repeatableProperty>
+    <f:repeatableProperty field="secretValues" minimum="1" add="Add a key/value pair" />
   </f:entry>
 
   <f:entry title="">
@@ -17,7 +17,7 @@
 
   <f:advanced title="Advanced Settings">
     <f:entry field="engineVersion" title="K/V Engine Version">
-      <f:select />
+      <f:select default="${descriptor.DEFAULT_ENGINE_VERSION}" />
     </f:entry>
   </f:advanced>
 

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/help-envVar.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/help-envVar.html
@@ -1,3 +1,4 @@
 <div>
-  The environment variable to set with the value of the vault key.
+  The environment variable to set with the value of the vault key.<br />
+  If field is left empty. The value from vault key will be used for environment variable.
 </div>


### PR DESCRIPTION
added symbol `withVault` and improved step generator by using fixEmptyAndTrim

So now it spits out a block like this:
```groovy
withVault(configuration: [vaultUrl: 'https://vault'], vaultSecrets: [[path: '/secret/a', secretValues: [[vaultKey: 'key']]]]) {
    // some block
}
```

For `VaultSecretValue` I made `envKey` optional so when it is left empty `vaultKey` will be used for the environment variable. Making the pipeline less verbose

I switched `VaultConfiguration` to an empty constructor