### PR TITLE
add support for vault agent

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -55,6 +55,11 @@
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
+    <codeStyleSettings language="Groovy">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="HTML">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />

--- a/pom.xml
+++ b/pom.xml
@@ -201,12 +201,16 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>vault</artifactId>
-      <version>1.10.6</version>
+      <version>1.12.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
-    <configuration-as-code.version>1.28</configuration-as-code.version>
+    <configuration-as-code.version>1.29</configuration-as-code.version>
   </properties>
   <name>HashiCorp Vault Plugin</name>
   <description>Build Wrapper for reading secrets in a HashiCorp Vault</description>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>4.0.0</version>
+      <version>5.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <revision>2.4.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     <configuration-as-code.version>1.28</configuration-as-code.version>
@@ -116,53 +116,45 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <!-- FilePathUtils -->
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <!-- StepConfigTester -->
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <!-- SemaphoreStep -->
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>2.1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>com.bettercloud</groupId>
@@ -172,17 +164,16 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>6.0.3</version>
+      <version>6.9</version><!-- Switch to BOM once released -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.16</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
-      <version>1.16</version>
+      <version>1.18</version><!-- Switch to BOM once released -->
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -220,4 +211,15 @@
       </exclusions>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.138.1</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/GlobalVaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/GlobalVaultConfiguration.java
@@ -6,10 +6,12 @@ import hudson.Extension;
 import hudson.model.Item;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 @Extension
+@Symbol("hashicorpVault")
 public class GlobalVaultConfiguration extends GlobalConfiguration {
 
     private VaultConfiguration configuration;

--- a/src/test/java/com/datapipe/jenkins/vault/VaultBuildWrapperWithMockAccessor.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultBuildWrapperWithMockAccessor.java
@@ -1,6 +1,7 @@
 package com.datapipe.jenkins.vault;
 
 import com.bettercloud.vault.response.LogicalResponse;
+import com.bettercloud.vault.rest.RestResponse;
 import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential;
 import com.datapipe.jenkins.vault.credentials.VaultCredential;
 import com.datapipe.jenkins.vault.model.VaultSecret;
@@ -52,7 +53,11 @@ public class VaultBuildWrapperWithMockAccessor extends VaultBuildWrapper {
                 Map<String, String> returnValue = new HashMap<>();
                 returnValue.put("key1", "some-secret");
                 LogicalResponse resp = mock(LogicalResponse.class);
+                RestResponse rest = mock(RestResponse.class);
                 when(resp.getData()).thenReturn(returnValue);
+                when(resp.getData()).thenReturn(returnValue);
+                when(resp.getRestResponse()).thenReturn(rest);
+                when(rest.getStatus()).thenReturn(200);
                 return resp;
             }
         });

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
@@ -2,6 +2,7 @@ package com.datapipe.jenkins.vault.it;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.response.LogicalResponse;
+import com.bettercloud.vault.rest.RestResponse;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -96,7 +97,10 @@ public class VaultConfigurationIT {
         Map<String, String> returnValue = new HashMap<>();
         returnValue.put("key1", "some-secret");
         LogicalResponse resp = mock(LogicalResponse.class);
+        RestResponse rest = mock(RestResponse.class);
         when(resp.getData()).thenReturn(returnValue);
+        when(resp.getRestResponse()).thenReturn(rest);
+        when(rest.getStatus()).thenReturn(200);
         when(vaultAccessor.read("secret/path1", engineVersion)).thenReturn(resp);
         return vaultAccessor;
     }

--- a/src/test/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultTestUtil.java
+++ b/src/test/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultTestUtil.java
@@ -11,10 +11,14 @@ import java.util.HashMap;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.TestEnvironment;
 import org.testcontainers.vault.VaultContainer;
+
+import static com.github.dockerjava.api.model.Capability.IPC_LOCK;
+import static org.apache.commons.io.FileUtils.writeStringToFile;
+import static org.testcontainers.utility.MountableFile.forHostPath;
 
 @SuppressWarnings("WeakerAccess")
 class VaultTestUtil {
@@ -33,6 +37,7 @@ class VaultTestUtil {
     public static final String VAULT_PATH_KV2_AUTH_TEST = "kv-v2/auth-test";
     public static final String VAULT_APPROLE_FILE = "JCasC_temp_approle_secret.prop";
     private static boolean configured = false;
+    private static Network network = Network.newNetwork();
 
     public static void runCommand(VaultContainer container, final String... command)
         throws IOException, InterruptedException {
@@ -49,18 +54,42 @@ class VaultTestUtil {
     }
 
     public static VaultContainer createVaultContainer() {
-        if (!hasDockerDaemon()) return null;
+        if (!hasDockerDaemon()) {
+            return null;
+        }
         return new VaultContainer<>(VaultTestUtil.VAULT_DOCKER_IMAGE)
-                .withVaultToken(VaultTestUtil.VAULT_ROOT_TOKEN)
-                .withCopyFileToContainer(MountableFile.forHostPath(
-                        VaultTestUtil.class.getResource("vaultTest_adminPolicy.hcl").getPath()),
-                        "/admin.hcl")
-                .withVaultPort(8200)
-                .waitingFor(Wait.forHttp("/v1/sys/seal-status").forStatusCode(200));
+            .withVaultToken(VaultTestUtil.VAULT_ROOT_TOKEN)
+            .withNetwork(network)
+            .withNetworkAliases("vault")
+            .withCopyFileToContainer(forHostPath(
+                VaultTestUtil.class.getResource("vaultTest_adminPolicy.hcl").getPath()),
+                "/admin.hcl")
+            .withVaultPort(8200)
+            .waitingFor(Wait.forHttp("/v1/sys/seal-status").forStatusCode(200));
+    }
+
+    public static VaultContainer createVaultAgentContainer(
+        Path roleIDPath,
+        Path secretIDPath) {
+        return new VaultContainer<>("vault:1.2.1")
+            .withNetwork(network)
+            .withCreateContainerCmdModifier(cmd -> cmd.withCapAdd(IPC_LOCK))
+            .withCopyFileToContainer(forHostPath(
+                VaultTestUtil.class.getResource("vaultTest_agent.hcl").getPath()),
+                "/agent.hcl")
+            .withCopyFileToContainer(forHostPath(roleIDPath),
+                "/home/vault/role_id")
+            .withCopyFileToContainer(forHostPath(secretIDPath),
+                "/home/vault/secret_id")
+            .withCommand("vault agent -config=/agent.hcl -address=http://vault:8200")
+            .withVaultPort(8100)
+            .waitingFor(Wait.forLogMessage(".*renewed auth token.*", 1));
     }
 
     public static void configureVaultContainer(VaultContainer container) {
-        if (configured) return;
+        if (configured) {
+            return;
+        }
         try {
             // Create Secret Backends
             runCommand(container, "vault", "secrets", "enable", "-path=kv-v2",
@@ -99,6 +128,10 @@ class VaultTestUtil {
             File file = filePath.toFile();
             FileOutputStream fos = new FileOutputStream(file);
             properties.store(fos, null);
+            Path roleIDPath = Paths.get(System.getProperty("java.io.tmpdir"), "role_id");
+            Path secretIDPath = Paths.get(System.getProperty("java.io.tmpdir"), "secret_id");
+            writeStringToFile(roleIDPath.toFile(), roleID);
+            writeStringToFile(secretIDPath.toFile(), secretID);
 
             // add secrets for v1 and v2
             runCommand(container, "vault", "kv", "put", VAULT_PATH_KV1_1, "key1=123",
@@ -110,6 +143,10 @@ class VaultTestUtil {
             runCommand(container, "vault", "kv", "put", VAULT_PATH_KV2_3, "key2=321");
             runCommand(container, "vault", "kv", "put", VAULT_PATH_KV2_AUTH_TEST,
                 "key1=auth-test");
+            VaultContainer vaultAgentContainer = createVaultAgentContainer(roleIDPath,
+                secretIDPath);
+            assert vaultAgentContainer != null;
+            vaultAgentContainer.start();
             LOGGER.log(Level.INFO, "Vault is configured");
             configured = true;
         } catch (Exception e) {

--- a/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/pipeline.groovy
+++ b/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/pipeline.groovy
@@ -1,0 +1,14 @@
+//noinspection GrPackage
+node {
+    def secrets = [
+        [
+            path: 'secret/testing',
+            secretValues: [
+                [envVar: 'testing', vaultKey: 'value_one']
+            ]
+        ]
+    ]
+    withVault([vaultSecrets: secrets]) {
+        echo '${env.testing}'
+    }
+}

--- a/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/vault.yml
+++ b/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/vault.yml
@@ -1,2 +1,18 @@
 jenkins:
   systemMessage: "Test '{key1}', '{key2}', '{key3}'"
+
+unclassified:
+  hashicorpVault:
+    configuration:
+      vaultCredentialId: "vaultToken"
+      vaultUrl: "${CASC_VAULT_AGENT_ADDR:-http://localhost:8100}" # Vault Agent Addr
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - vaultTokenCredential:
+              description: "Uber Token"
+              id: "vaultToken"
+              scope: GLOBAL
+              token: ""

--- a/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/vaultTest_agent.hcl
+++ b/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/vaultTest_agent.hcl
@@ -1,0 +1,23 @@
+pid_file = "/tmp/agent_pidfile"
+auto_auth {
+    method {
+        type = "approle"
+        config = {
+            role_id_file_path = "/home/vault/role_id"
+            secret_id_file_path = "/home/vault/secret_id"
+        }
+    }
+    sink {
+        type = "file"
+        config = {
+            path = "/tmp/file-foo"
+        }
+    }
+}
+cache {
+    use_auto_auth_token = true
+}
+listener "tcp" {
+    address = "0.0.0.0:8200"
+    tls_disable = true
+}


### PR DESCRIPTION
Needed to bump credentials plugin to validate credential configuration via configuration-as-code.
Which means I needed to bump Jenkins version.

Bumped optional dependency of configuration-as-code which fixes vault initialization being called too late. :scream:

fixes https://github.com/jenkinsci/configuration-as-code-plugin/issues/967