### PR TITLE
CasC: allow login by Kubernetes ServiceAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The secret source for JCasC is configured via environment variables as way to ge
 - The environment variable `CASC_VAULT_USER` must be present, if token is not used and appRole/Secret is not used. (Vault username.)
 - The environment variable `CASC_VAULT_APPROLE` must be present, if token is not used and U/P not used. (Vault AppRole ID.)
 - The environment variable `CASC_VAULT_APPROLE_SECRET` must be present, it token is not used and U/P not used. (Vault AppRole Secret ID.)
+- The environment variable `CASC_VAULT_KUBERNETES_ROLE` must be present, if you want to use Kubernetes Service Account. (Vault Kubernetes Role.)
 - The environment variable `CASC_VAULT_TOKEN` must be present, if U/P is not used. (Vault token.)
 - The environment variable `CASC_VAULT_PATHS` must be present. (Comma separated vault key paths. For example, `secret/jenkins,secret/admin`.)
 - The environment variable `CASC_VAULT_URL` must be present. (Vault url, including port number.)
@@ -225,7 +226,7 @@ The secret source for JCasC is configured via environment variables as way to ge
 - The environment variable `CASC_VAULT_ENGINE_VERSION` is optional. If unset, your vault path is assumed to be using kv version 2. If your vault path uses engine version 1, set this variable to `1`.
 - The issued token should have read access to vault path `auth/token/lookup-self` in order to determine its expiration time. JCasC will re-issue a token if its expiration is reached (except for `CASC_VAULT_TOKEN`).
 
-If the environment variables `CASC_VAULT_URL` and `CASC_VAULT_PATHS` are present, JCasC will try to gather initial secrets from Vault. However for it to work properly there is a need for authentication by either the combination of `CASC_VAULT_USER` and `CASC_VAULT_PW`, a `CASC_VAULT_TOKEN`, or the combination of `CASC_VAULT_APPROLE` and `CASC_VAULT_APPROLE_SECRET`. The authenticated user must have at least read access.
+If the environment variables `CASC_VAULT_URL` and `CASC_VAULT_PATHS` are present, JCasC will try to gather initial secrets from Vault. However for it to work properly there is a need for authentication by either the combination of `CASC_VAULT_USER` and `CASC_VAULT_PW`, a `CASC_VAULT_TOKEN`, the combination of `CASC_VAULT_APPROLE` and `CASC_VAULT_APPROLE_SECRET`, or a `CASC_VAULT_KUBERNETES_ROLE`. The authenticated user must have at least read access.
 
 You can also provide a `CASC_VAULT_FILE` environment variable where you load the secrets from a file.
 

--- a/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultAuthenticator.java
+++ b/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultAuthenticator.java
@@ -15,4 +15,7 @@ public interface VaultAuthenticator {
     static VaultAuthenticator of(VaultUsernamePassword vaultUsernamePassword, String mountPath) {
         return new VaultUserPassAuthenticator(vaultUsernamePassword, mountPath);
     }
+    static VaultAuthenticator of(VaultKubernetes vaultKubernetes, String mountPath) {
+        return new VaultKubernetesAuthenticator(vaultKubernetes, mountPath);
+    }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultKubernetes.java
+++ b/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultKubernetes.java
@@ -1,0 +1,24 @@
+package com.datapipe.jenkins.vault.jcasc.secrets;
+
+import java.util.Objects;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.ProtectedExternally;
+
+
+@Restricted(ProtectedExternally.class)
+public class VaultKubernetes {
+    private String role;
+
+    public VaultKubernetes(String role) {
+        this.role = role;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(role);
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultKubernetesAuthenticator.java
+++ b/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultKubernetesAuthenticator.java
@@ -1,0 +1,62 @@
+package com.datapipe.jenkins.vault.jcasc.secrets;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class VaultKubernetesAuthenticator extends VaultAuthenticatorWithExpiration {
+    private final static Logger LOGGER = Logger.getLogger(VaultKubernetesAuthenticator.class.getName());
+
+    private static final String SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+    private VaultKubernetes kubernetes;
+
+    private String mountPath;
+
+    private String jwt;
+
+    public VaultKubernetesAuthenticator(VaultKubernetes kubernetes, String mountPath) {
+        this.kubernetes = kubernetes;
+        this.mountPath = mountPath;
+    }
+
+    @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
+    public void authenticate(Vault vault, VaultConfig config) throws VaultException, VaultPluginException {
+        if (isTokenTTLExpired()) {
+            try {
+                this.jwt = Files.lines(Paths.get(SERVICE_ACCOUNT_TOKEN_PATH)).collect(Collectors.joining());
+            } catch (IOException e) {
+                throw new VaultPluginException("could not get JWT from Service Account Token", e);
+            }
+            // authenticate
+            currentAuthToken = vault.auth()
+                .loginByJwt(mountPath, kubernetes.getRole(), this.jwt)
+                .getAuthClientToken();
+            config.token(currentAuthToken).build();
+            LOGGER.log(Level.FINE, "Login to Vault using Kubernetes successful");
+            getTTLExpiryOfCurrentToken(vault);
+        } else {
+            // make sure current auth token is set in config
+            config.token(currentAuthToken).build();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kubernetes);
+    }
+}


### PR DESCRIPTION
This PR is based on the work done in #52 and allows to use Kubernetes Service Account while using CasC.

As the other authentication methods, a `CASC_VAULT_KUBERNETES_ROLE` parameter is needed to enable this methods. 

I wasn't able to add tests because we would need to have a Kubernetes instance running to validate the token (or mock something).