### PR TITLE
Support prefixPath field

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The secret source for JCasC is configured via environment variables as way to ge
 - The environment variable `CASC_VAULT_AGENT_ADDR` is optional. It takes precedence over `CASC_VAULT_URL` and is used for connecting to a Vault Agent. [See this section](#vault-agent)
 - The environment variable `CASC_VAULT_MOUNT` is optional. (Vault auth mount. For example, `ldap` or another username & password authentication type, defaults to `userpass`.)
 - The environment variable `CASC_VAULT_NAMESPACE` is optional. If used, sets the Vault namespace for Enterprise Vaults.
+- The environment variable `CASC_VAULT_PREFIX_PATH` is optional. If used, allows to use complex prefix paths (for example with KV secrets available at `my/long/data/prefix/kv/secret1` set this to `my/long/data/prefix/kv`).
 - The environment variable `CASC_VAULT_FILE` is optional, provides a way for the other variables to be read from a file instead of environment variables.
 - The environment variable `CASC_VAULT_ENGINE_VERSION` is optional. If unset, your vault path is assumed to be using kv version 2. If your vault path uses engine version 1, set this variable to `1`.
 - The issued token should have read access to vault path `auth/token/lookup-self` in order to determine its expiration time. JCasC will re-issue a token if its expiration is reached (except for `CASC_VAULT_TOKEN`).

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>5.0.0</version>
+      <version>5.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
@@ -47,6 +47,8 @@ public class VaultConfiguration
 
     private String vaultNamespace;
 
+    private String prefixPath;
+
     private Integer timeout = DEFAULT_TIMEOUT;
 
     @DataBoundConstructor
@@ -68,6 +70,7 @@ public class VaultConfiguration
         this.skipSslVerification = toCopy.skipSslVerification;
         this.engineVersion = toCopy.engineVersion;
         this.vaultNamespace = toCopy.vaultNamespace;
+        this.prefixPath = toCopy.prefixPath;
         this.timeout = toCopy.timeout;
     }
 
@@ -87,6 +90,9 @@ public class VaultConfiguration
         }
         if (StringUtils.isBlank(result.getVaultNamespace())) {
             result.setVaultNamespace(parent.getVaultNamespace());
+        }
+        if (StringUtils.isBlank(result.getPrefixPath())) {
+            result.setPrefixPath(parent.getPrefixPath());
         }
         if (result.timeout == null) {
             result.setTimeout(parent.getTimeout());
@@ -147,6 +153,15 @@ public class VaultConfiguration
     @DataBoundSetter
     public void setVaultNamespace(String vaultNamespace) {
         this.vaultNamespace = fixEmptyAndTrim(vaultNamespace);
+    }
+
+    public String getPrefixPath() {
+        return prefixPath;
+    }
+
+    @DataBoundSetter
+    public void setPrefixPath(String prefixPath) {
+        this.prefixPath = fixEmptyAndTrim(prefixPath);
     }
 
     public Integer getTimeout() {
@@ -220,6 +235,10 @@ public class VaultConfiguration
 
             if (StringUtils.isNotEmpty(this.getVaultNamespace())) {
                 vaultConfig.nameSpace(this.getVaultNamespace());
+            }
+
+            if (StringUtils.isNotEmpty(this.getPrefixPath())) {
+                vaultConfig.prefixPath(this.getPrefixPath());
             }
         } catch (VaultException e) {
             throw new VaultPluginException("Could not set up VaultConfig.", e);

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
@@ -149,6 +149,10 @@ public class VaultUsernamePasswordCredentialImpl extends BaseStandardCredentials
                 vaultConfig.nameSpace(globalConfig.getConfiguration().getVaultNamespace());
             }
 
+            if (StringUtils.isNotEmpty(globalConfig.getConfiguration().getPrefixPath())) {
+                vaultConfig.prefixPath(globalConfig.getConfiguration().getPrefixPath());
+            }
+
             VaultCredential vaultCredential = retrieveVaultCredentials(
                 globalConfig.getConfiguration().getVaultCredentialId());
 

--- a/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSource.java
+++ b/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSource.java
@@ -36,6 +36,7 @@ public class VaultSecretSource extends SecretSource {
     private static final String CASC_VAULT_APPROLE = "CASC_VAULT_APPROLE";
     private static final String CASC_VAULT_APPROLE_SECRET = "CASC_VAULT_APPROLE_SECRET";
     private static final String CASC_VAULT_NAMESPACE = "CASC_VAULT_NAMESPACE";
+    private static final String CASC_VAULT_PREFIX_PATH = "CASC_VAULT_PREFIX_PATH";
     private static final String CASC_VAULT_ENGINE_VERSION = "CASC_VAULT_ENGINE_VERSION";
     private static final String CASC_VAULT_PATHS = "CASC_VAULT_PATHS";
     private static final String CASC_VAULT_PATH = "CASC_VAULT_PATH"; // TODO: deprecate!
@@ -63,6 +64,7 @@ public class VaultSecretSource extends SecretSource {
             .map(Optional::of)
             .orElseGet(() -> getVariable(CASC_VAULT_URL));
         Optional<String> vaultNamespace = getVariable(CASC_VAULT_NAMESPACE);
+        Optional<String> vaultPrefixPath = getVariable(CASC_VAULT_PREFIX_PATH);
         Optional<String[]> vaultPaths = getCommaSeparatedVariables(CASC_VAULT_PATHS);
         getVariable(CASC_VAULT_PATH).ifPresent(s -> LOGGER
             .log(Level.SEVERE, "{0} is deprecated, please switch to {1}",
@@ -88,6 +90,11 @@ public class VaultSecretSource extends SecretSource {
 
             vaultConfig.engineVersion(Integer.parseInt(vaultEngineVersion));
             LOGGER.log(Level.FINE, "Using engine version: {0}", vaultEngineVersion);
+
+            if (vaultPrefixPath.isPresent()) {
+                vaultConfig.prefixPath(vaultPrefixPath.get());
+                LOGGER.log(Level.FINE, "Using prefixPath with Vault: {0}", vaultPrefixPath);
+            }
         } catch (VaultException e) {
             LOGGER.log(Level.WARNING, "Could not configure vault connection", e);
         }

--- a/src/test/java/com/datapipe/jenkins/vault/configuration/VaultConfigurationSpec.java
+++ b/src/test/java/com/datapipe/jenkins/vault/configuration/VaultConfigurationSpec.java
@@ -106,4 +106,14 @@ public class VaultConfigurationSpec {
         parent.setTimeout(20);
         assertThat(parent.isFailIfNotFound(), is(false));
     }
+
+    @Test
+    public void shouldStorePrefixPath() {
+        VaultConfiguration parent = new VaultConfiguration();
+        parent.setVaultUrl("http://vault-url.com/");
+        parent.setFailIfNotFound(false);
+        parent.setPrefixPath("my/custom/prefixpath");
+        parent.setTimeout(20);
+        assertThat(parent.getPrefixPath(), is("my/custom/prefixpath"));
+    }
 }

--- a/src/test/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSourceTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSourceTest.java
@@ -110,6 +110,19 @@ public class VaultSecretSourceTest implements TestConstants {
     @Test
     @ConfiguredWithCode("vault.yml")
     @Envs({
+        @Env(name = "CASC_VAULT_USER", value = VAULT_USER),
+        @Env(name = "CASC_VAULT_PW", value = VAULT_PW),
+        @Env(name = "CASC_VAULT_PATHS", value = VAULT_PATH_LONG_KV2_1 + "," + VAULT_PATH_LONG_KV2_2),
+        @Env(name = "CASC_VAULT_PREFIX_PATH", value = VAULT_PATH_LONG_KV2_PREFIX_PATH),
+        @Env(name = "CASC_VAULT_ENGINE_VERSION", value = "2")
+    })
+    public void kv2WithLongPathAndUser() {
+        assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+    }
+
+    @Test
+    @ConfiguredWithCode("vault.yml")
+    @Envs({
         @Env(name = "CASC_VAULT_USER", value = "1234"),
         @Env(name = "CASC_VAULT_PW", value = VAULT_PW),
         @Env(name = "CASC_VAULT_PATHS", value = VAULT_PATH_KV2_1),

--- a/src/test/java/com/datapipe/jenkins/vault/util/TestConstants.java
+++ b/src/test/java/com/datapipe/jenkins/vault/util/TestConstants.java
@@ -37,6 +37,9 @@ public interface TestConstants {
     String VAULT_PATH_KV2_2 = "kv-v2/dev";
     String VAULT_PATH_KV2_3 = "kv-v2/qa";
     String VAULT_PATH_KV2_AUTH_TEST = "kv-v2/auth-test";
+    String VAULT_PATH_LONG_KV2_1 = "long/path/kv-v2/admin";
+    String VAULT_PATH_LONG_KV2_2 = "long/path/kv-v2/dev";
+    String VAULT_PATH_LONG_KV2_PREFIX_PATH = "long/path/kv-v2";
     String VAULT_APPROLE_FILE = "JCasC_temp_approle_secret.prop";
     String VAULT_AGENT_FILE = "JCasC_temp_vault_agent.prop";
 }

--- a/src/test/java/com/datapipe/jenkins/vault/util/VaultTestUtil.java
+++ b/src/test/java/com/datapipe/jenkins/vault/util/VaultTestUtil.java
@@ -88,6 +88,8 @@ public class VaultTestUtil implements TestConstants {
             // Create Secret Backends
             runCommand(container, "vault", "secrets", "enable", "-path=kv-v2",
                 "-version=2", "kv");
+            runCommand(container, "vault", "secrets", "enable", "-path=long/path/kv-v2",
+                "-version=2", "kv");
             runCommand(container, "vault", "secrets", "enable", "-path=kv-v1",
                 "-version=1", "kv");
 
@@ -137,6 +139,9 @@ public class VaultTestUtil implements TestConstants {
             runCommand(container, "vault", "kv", "put", VAULT_PATH_KV2_3, "key2=321");
             runCommand(container, "vault", "kv", "put", VAULT_PATH_KV2_AUTH_TEST,
                 "key1=auth-test");
+            runCommand(container, "vault", "kv", "put", VAULT_PATH_LONG_KV2_1, "key1=123",
+                "key2=456");
+            runCommand(container, "vault", "kv", "put", VAULT_PATH_LONG_KV2_2, "key3=789");
             VaultContainer vaultAgentContainer = createVaultAgentContainer(roleIDPath,
                 secretIDPath);
             assert vaultAgentContainer != null;

--- a/src/test/resources/com/datapipe/jenkins/vault/util/vaultTest_adminPolicy.hcl
+++ b/src/test/resources/com/datapipe/jenkins/vault/util/vaultTest_adminPolicy.hcl
@@ -10,6 +10,10 @@ path "kv-v2/*" {
     capabilities = ["create", "read", "list"]
 }
 
+path "long/path/kv-v2/*" {
+    capabilities = ["create", "read", "list"]
+}
+
 path "auth/token/lookup-self" {
     capabilities = ["read"]
 }


### PR DESCRIPTION
This PR updates vault-java-driver and implements support for prefixPath field (ref https://github.com/BetterCloud/vault-java-driver/pull/189 )

With it, it's now possible to use secrets with a custom prefix (for example `my/custom/prefix/kv/secret1`).