### PR TITLE
Use try-with-resources when reading kubernetes service account token.

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -46,8 +47,8 @@ public class VaultKubernetesCredential extends AbstractVaultTokenCredential {
     @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
     public String getToken(Vault vault) {
         String jwt;
-        try {
-            jwt = Files.lines(Paths.get(SERVICE_ACCOUNT_TOKEN_PATH)).collect(Collectors.joining());
+        try (Stream<String> input =  Files.lines(Paths.get(SERVICE_ACCOUNT_TOKEN_PATH)) ) {
+            jwt = input.collect(Collectors.joining());
         } catch (IOException e) {
             throw new VaultPluginException("could not get JWT from Service Account Token", e);
         }

--- a/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultKubernetesAuthenticator.java
+++ b/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultKubernetesAuthenticator.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class VaultKubernetesAuthenticator extends VaultAuthenticatorWithExpiration {
     private final static Logger LOGGER = Logger.getLogger(VaultKubernetesAuthenticator.class.getName());
@@ -32,8 +33,8 @@ public class VaultKubernetesAuthenticator extends VaultAuthenticatorWithExpirati
     @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
     public void authenticate(Vault vault, VaultConfig config) throws VaultException, VaultPluginException {
         if (isTokenTTLExpired()) {
-            try {
-                this.jwt = Files.lines(Paths.get(SERVICE_ACCOUNT_TOKEN_PATH)).collect(Collectors.joining());
+            try (Stream<String> input =  Files.lines(Paths.get(SERVICE_ACCOUNT_TOKEN_PATH)) ) {
+                this.jwt = input.collect(Collectors.joining());
             } catch (IOException e) {
                 throw new VaultPluginException("could not get JWT from Service Account Token", e);
             }


### PR DESCRIPTION
Hi,
We're using the plugin to inject git credentials into jobs. It works really well, except there seems to be a file descriptor leak somewhere in the code specifically to the kubernetes service account token.

I've created this issue https://issues.jenkins-ci.org/browse/JENKINS-61437

I think the culprit is `Files.lines` because as stated in the documentation https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#lines-java.nio.file.Path-java.nio.charset.Charset- 

>  If timely disposal of file system resources is required, the try-with-resources construct should be used to ensure that the stream's close method is invoked after the stream operations are completed.

All tests pass when running on my machine.