### PR TITLE
add full path variables to jcasc secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/hashicorp-vault-plugin/master)](https://ci.jenkins.io/job/Plugins/job/hashicorp-vault-plugin/job/master/)
 # Jenkins Vault Plugin
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/hashicorp-vault-plugin/master)](https://ci.jenkins.io/job/Plugins/job/hashicorp-vault-plugin/job/master/)
 # Jenkins Vault Plugin
 
@@ -222,7 +223,7 @@ credentials:
               token: "${MY_SECRET_TOKEN}"
 ```
 
-See [handling secrets section](https://github.com/jenkinsci/configuration-as-code-plugin#handling-secrets) in JCasC documentation for better security.
+See [handling secrets section](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc) in JCasC documentation for better security.
 
 You can also configure `VaultGithubTokenCredential`, or `VautGCPCredential` or `VaultAppRoleCredential`
 
@@ -294,6 +295,25 @@ volumes:
 secrets:
   jcasc_vault:
     file: ./secrets/jcasc_vault
+```
+#### Example: HashiCorp Vault Plugin as a Secret Source for JCasC
+Assume Vault has a secret at path `secret/jenkins/passwords` with keys `secretKey1` and `secretKey2`.  Set the value for environment variable `CASC_VAULT_PATHS` to `secret/jenkins/passwords`.
+The Hashicorp Vault Plugin provides two ways of accessing the secrets: using just the key within the secret and using the full path to the secret key.  The full path option allows for you to reference multiple secrets with overlapping keys.
+```yaml
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - string:
+              description: "Secret using only secret key name"
+              id: "secretUsingKey"
+              scope: GLOBAL
+              token: "${secretKey1}"
+          - string:
+              description: "Secret using full path"
+              id: "secretUsingKey"
+              scope: GLOBAL
+              token: "${secret/jenkins/passwords/secretKey1}"
 ```
 
 ### Vault Agent

--- a/src/test/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSourceTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSourceTest.java
@@ -93,6 +93,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv1WithUser() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV1_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -105,6 +106,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithUser() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -118,6 +120,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithLongPathAndUser() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_LONG_KV2_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -130,6 +133,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithWrongUser() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo(""));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key1}"), equalTo(""));
     }
 
     @Test
@@ -141,6 +145,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv1WithToken() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV1_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -152,6 +157,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithToken() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -163,6 +169,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv1WithWrongToken() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo(""));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV1_1 + "/key1}"), equalTo(""));
     }
 
     @Test
@@ -174,6 +181,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv1WithApprole() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV1_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -185,6 +193,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithApprole() throws ConfiguratorException {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -197,6 +206,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithWrongApprole() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo(""));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key1}"), equalTo(""));
     }
 
     @Test
@@ -208,7 +218,9 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithApproleMultipleKeys() {
         assertThat(SecretSourceResolver.resolve(context, "${key2}"), equalTo("456"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key2}"), equalTo("456"));
         assertThat(SecretSourceResolver.resolve(context, "${key3}"), equalTo("789"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_2 + "/key3}"), equalTo("789"));
     }
 
     @Test
@@ -220,7 +232,10 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv2WithApproleMultipleKeysOverriden() {
         assertThat(SecretSourceResolver.resolve(context, "${key2}"), equalTo("321"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key2}"), equalTo("456"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_3 + "/key2}"), equalTo("321"));
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV2_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -259,6 +274,7 @@ public class VaultSecretSourceTest implements TestConstants {
     })
     public void kv1WithAgent() {
         assertThat(SecretSourceResolver.resolve(context, "${key1}"), equalTo("123"));
+        assertThat(SecretSourceResolver.resolve(context, "${" + VAULT_PATH_KV1_1 + "/key1}"), equalTo("123"));
     }
 
     @Test
@@ -273,5 +289,16 @@ public class VaultSecretSourceTest implements TestConstants {
 
         j.assertBuildStatus(Result.FAILURE, build);
         j.assertLogContains("Vault credentials not found for '" + VAULT_PATH_KV1_1 + "'", build);
+    }
+
+    @Test
+    @ConfiguredWithCode("vault.yml")
+    @EnvsFromFile(VAULT_APPROLE_FILE)
+    @Envs({
+        @Env(name = "CASC_VAULT_PATHS", value = VAULT_PATH_KV2_1 + "," + VAULT_PATH_KV2_2),
+        @Env(name = "CASC_VAULT_ENGINE_VERSION", value = "2")
+    })
+    public void kv2ValidateJsacYaml() {
+        assertThat(j.jenkins.getSystemMessage(), equalTo("Test '123', '456', '789'"));
     }
 }

--- a/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/vault.yml
+++ b/src/test/resources/com/datapipe/jenkins/vault/jcasc/secrets/vault.yml
@@ -1,5 +1,5 @@
 jenkins:
-  systemMessage: "Test '{key1}', '{key2}', '{key3}'"
+  systemMessage: "Test '${key1}', '${key2}', '${kv-v2/dev/key3}'"
 
 unclassified:
   hashicorpVault:


### PR DESCRIPTION
This change makes it's possible to use the full path of secret in the jcasc configuration.  This way multiple secrets with the same key can be used. Resolves #85 