### PR TITLE
update jenkins version to 2.164.3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,15 +8,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [1.8, 11]
-        jenkins-version: [2.138.4, 2.190.1]
+        java: [8, 11]
+        jenkins-version: [2.164.3, 2.222.1]
         os: [ubuntu-latest, windows-latest]
         include:
-          - jenkins-version: '2.190.1'
-            flags: '--define jenkins.version=2.190.1 --define slf4jVersion=1.7.26'
-        exclude:
-          - java: '11'
-            jenkins-version: '2.138.4'
+          - jenkins-version: '2.222.1'
+            flags: '--define jenkins.version=2.222.1'
 
     steps:
       - uses: actions/checkout@v1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
-def recentLTS = "2.164.1"
+def recentLTS = "2.222.1"
 def configurations = [
     [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
+    [ platform: "linux", jdk: "8", jenkins: recentLTS ],
+    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
     [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
 ]
 buildPlugin(configurations: configurations, findbugs: [archive: true])

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <revision>3.3.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     <configuration-as-code.version>1.35</configuration-as-code.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.56</version>
+    <version>4.1</version>
     <relativePath />
   </parent>
   <groupId>com.datapipe.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,45 +112,7 @@
     </plugins>
   </build>
   <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <!-- FilePathUtils -->
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-basic-steps</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <!-- StepConfigTester -->
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <!-- SemaphoreStep -->
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-support</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
+    <!-- Plugin Dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
@@ -173,24 +135,14 @@
       <artifactId>credentials-binding</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- Test Dependencies -->
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -208,6 +160,47 @@
           <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.29</version>
+              <version>8.31</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>
   <name>HashiCorp Vault Plugin</name>
   <description>Reading secrets from HashiCorp Vault for a Pipeline or as a Secret Source for JCasC</description>
@@ -181,13 +180,11 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -217,8 +214,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.138.x</artifactId>
-        <version>3</version>
+        <artifactId>bom-2.164.x</artifactId>
+        <version>9</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
This enables us to use Jenkins Core BOM when using plugin pom v4
Also allows us to use Jenkins Core that supports java 11 by default.

Cleaned up the pom