### PR TITLE
Add Vault secret text credentials

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredential.java
@@ -1,0 +1,24 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+@NameWith(value = VaultStringCredential.NameProvider.class, priority = 32)
+public interface VaultStringCredential extends StringCredentials {
+
+    String getDisplayName();
+
+    class NameProvider extends CredentialsNameProvider<VaultStringCredential> {
+
+        @NonNull
+        @Override
+        public String getName(VaultStringCredential hashicorpVaultCredentials) {
+            String description = Util.fixEmpty(hashicorpVaultCredentials.getDescription());
+            return hashicorpVaultCredentials.getDisplayName() + (description == null ? ""
+                : " (" + description + ")");
+        }
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding.java
@@ -1,0 +1,52 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.credentialsbinding.Binding;
+import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class VaultStringCredentialBinding extends Binding<VaultStringCredential> {
+
+
+    @DataBoundConstructor
+    public VaultStringCredentialBinding(String variable, String credentialsId) {
+        super(variable, credentialsId);
+    }
+
+    @Override protected Class<VaultStringCredential> type() {
+        return VaultStringCredential.class;
+    }
+
+    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build,
+                                                  @Nullable FilePath workspace,
+                                                  @Nullable Launcher launcher,
+                                                  @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        return new SingleEnvironment(getCredentials(build).getSecret().getPlainText());
+    }
+
+    @Symbol("string")
+    @Extension
+    public static class DescriptorImpl extends BindingDescriptor<VaultStringCredential> {
+
+        @Override public boolean requiresWorkspace() {
+            return false;
+        }
+
+        @Override protected Class<VaultStringCredential> type() {
+            return VaultStringCredential.class;
+        }
+
+        @Override public String getDisplayName() {
+            return "Vault Secret Text Credential";
+        }
+
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding.java
@@ -32,7 +32,7 @@ public class VaultStringCredentialBinding extends Binding<VaultStringCredential>
         return new SingleEnvironment(getCredentials(build).getSecret().getPlainText());
     }
 
-    @Symbol("string")
+    @Symbol("vaultString")
     @Extension
     public static class DescriptorImpl extends BindingDescriptor<VaultStringCredential> {
 

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -92,15 +92,14 @@ public class VaultStringCredentialImpl extends BaseStandardCredentials implement
             @QueryParameter("vaultKey") String vaultKey,
             @QueryParameter("engineVersion") Integer engineVersion) {
 
-            String key = null;
             try {
-                key = getVaultSecret(path, defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY), engineVersion);
+                getVaultSecret(path, defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY), engineVersion);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve Vault secret: \n" + e);
             }
 
             return FormValidation
-                .ok("Successfully retrieved secret by key " + key);
+                .ok("Successfully retrieved secret by key " + vaultKey);
         }
 
         @SuppressWarnings("unused") // used by stapler

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -1,0 +1,111 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import static com.datapipe.jenkins.vault.configuration.VaultConfiguration.engineVersions;
+import static com.datapipe.jenkins.vault.credentials.common.VaultHelper.getVaultSecret;
+import static org.apache.commons.lang.StringUtils.defaultIfBlank;
+
+public class VaultStringCredentialImpl extends BaseStandardCredentials implements VaultStringCredential {
+
+    public static final String DEFAULT_VAULT_KEY = "secret";
+
+    private static final long serialVersionUID = 1L;
+
+    private String path;
+    private String vaultKey;
+    private Integer engineVersion;
+
+    @DataBoundConstructor
+    public VaultStringCredentialImpl(CredentialsScope scope, String id,
+        String description) {
+        super(scope, id, description);
+    }
+
+    @NonNull
+    public String getPath() {
+        return path;
+    }
+
+    @DataBoundSetter
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @NonNull
+    public String getVaultKey() {
+        return vaultKey;
+    }
+
+    @DataBoundSetter
+    public void setVaultKey(String vaultKey) {
+        this.vaultKey = defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY);
+    }
+
+    public Integer getEngineVersion() {
+        return engineVersion;
+    }
+
+    @DataBoundSetter
+    public void setEngineVersion(Integer engineVersion) {
+        this.engineVersion = engineVersion;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return this.path;
+    }
+
+    @NonNull
+    @Override
+    public Secret getSecret() {
+        String k = defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY);
+        String s = getVaultSecret(path, k, engineVersion);
+        if (s == null) {
+            throw new VaultPluginException("Fetching from Vault failed for key " + k, null);
+        }
+        return Secret.fromString(s);
+    }
+
+    @Extension(ordinal = 1)
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Vault Secret Text Credential";
+        }
+
+        public FormValidation doTestConnection(
+            @QueryParameter("path") String path,
+            @QueryParameter("vaultKey") String vaultKey,
+            @QueryParameter("engineVersion") Integer engineVersion) {
+
+            String key = null;
+            try {
+                key = getVaultSecret(path, defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY), engineVersion);
+            } catch (Exception e) {
+                return FormValidation.error("FAILED to retrieve Vault secret: \n" + e);
+            }
+
+            return FormValidation
+                .ok("Successfully retrieved secret by key " + key);
+        }
+
+        @SuppressWarnings("unused") // used by stapler
+        public ListBoxModel doFillEngineVersionItems(@AncestorInPath Item context) {
+            return engineVersions(context);
+        }
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -79,7 +79,7 @@ public class VaultStringCredentialImpl extends BaseStandardCredentials implement
         return Secret.fromString(s);
     }
 
-    @Extension(ordinal = 1)
+    @Extension
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
 
         @Override

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding/config-variables.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding/config-variables.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials">
+    <f:entry title="${%Variable}" field="variable">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding/help.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding/help.html
@@ -1,0 +1,3 @@
+<div>
+    Secret Text Jenkins credential backed by a Hashicorp Vault secret
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/credentials.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%Path}" field="path">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Vault Key}" field="vaultKey" default="secret">
+    <f:textbox/>
+  </f:entry>
+  <f:entry name="engineVersion" title="${%K/V Engine Version}" field="engineVersion">
+      <f:select/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+
+  <f:validateButton title="${%Test Vault Secrets retrieval}" progress="${%Testing retrieval of key...}"
+		method="testConnection" with="path,vaultKey,engineVersion" />
+
+</j:jelly>

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultStringCredentialIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultStringCredentialIT.java
@@ -1,0 +1,87 @@
+package com.datapipe.jenkins.vault.it;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.datapipe.jenkins.vault.credentials.common.VaultStringCredential;
+import com.datapipe.jenkins.vault.credentials.common.VaultStringCredentialImpl;
+import hudson.FilePath;
+import hudson.model.Result;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.getShellString;
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.getVariable;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VaultStringCredentialIT {
+
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Test
+    public void shouldRetrieveCorrectCredentialsFromVault() {
+        final String credentialsId = "cid1";
+        final String secret = "S3CR3T";
+        final String jobId = "testJob";
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                VaultStringCredential up = mock(VaultStringCredential.class);
+                when(up.getId()).thenReturn(credentialsId);
+                when(up.getSecret()).thenReturn(Secret.fromString(secret));
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                    .addCredentials(Domain.global(), up);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobId);
+                p.setDefinition(
+                    new CpsFlowDefinition(""
+                        + "node {\n"
+                        + " withCredentials([[$class: 'VaultStringCredentialBinding', credentialsId: '"
+                        + credentialsId
+                        + "', variable: 'SECRET']]) { "
+                        + "      " + getShellString() + " 'echo " + getVariable("SECRET") + " > secret.txt'\n"
+                        + "  }\n"
+                        + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(b));
+                story.j.assertLogNotContains(secret, b);
+                FilePath script = story.j.jenkins.getWorkspaceFor(p).child("secret.txt");
+                assertEquals(secret, script.readToString().trim());
+            }
+        });
+    }
+
+    @Test
+    public void shouldFailIfMissingCredentials() {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                final String credentialsId = "cid1";
+                VaultStringCredentialImpl c = new VaultStringCredentialImpl(
+                    null, credentialsId, "Test Credentials");
+                c.setEngineVersion(1);
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                    .addCredentials(Domain.global(), c);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "testJob");
+                p.setDefinition(new CpsFlowDefinition(""
+                    + "node {\n"
+                    + " withCredentials([[$class: 'VaultStringCredentialBinding', credentialsId: '"
+                    + credentialsId
+                    + "', variable: 'SECRET']]) { "
+                    + "      " + getShellString() + " 'echo " + getVariable("SECRET") + "'\n"
+                    + "  }\n"
+                    + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b));
+                story.j.assertLogContains("Exception", b);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Hi!

Would you please consider for inclusion the following PR that adds VaultStringCredential, i.e. the secret text type of credential fetched from Vault.

I'm trying to move all secrets from Jenkins to Vault and I needed this on several occasions.

Please, let me know if anything in the PR should be different or improved.  I have some doubts about the integration test, but I tried to mimic the existing tests as much as possible.

Thanks,
Josip