### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,4 @@ def configurations = [
     [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
     [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
 ]
-buildPlugin(configurations: configurations, findbugs: [archive: true])
+buildPlugin(configurations: configurations)


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.