### PR TITLE
Set default engineVersion to be consistent with documentation

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
@@ -30,6 +30,7 @@ public class VaultSSHUserPrivateKeyImpl extends BaseStandardCredentials implemen
     public static final String DEFAULT_USERNAME_KEY = "username";
     public static final String DEFAULT_PRIVATE_KEY_KEY = "private_key";
     public static final String DEFAULT_PASSPHRASE_KEY = "passphrase";
+    public static final Integer DEFAULT_ENGINE_VERSION = 2;
 
     private static final long serialVersionUID = 1L;
 
@@ -43,6 +44,7 @@ public class VaultSSHUserPrivateKeyImpl extends BaseStandardCredentials implemen
     public VaultSSHUserPrivateKeyImpl(CredentialsScope scope, String id,
         String description) {
         super(scope, id, description);
+        setEngineVersion(DEFAULT_ENGINE_VERSION);
     }
 
     @NonNull

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -21,6 +21,7 @@ import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 public class VaultStringCredentialImpl extends BaseStandardCredentials implements VaultStringCredential {
 
     public static final String DEFAULT_VAULT_KEY = "secret";
+    public static final Integer DEFAULT_ENGINE_VERSION = 2;
 
     private static final long serialVersionUID = 1L;
 
@@ -32,6 +33,7 @@ public class VaultStringCredentialImpl extends BaseStandardCredentials implement
     public VaultStringCredentialImpl(CredentialsScope scope, String id,
         String description) {
         super(scope, id, description);
+        setEngineVersion(DEFAULT_ENGINE_VERSION);
     }
 
     @NonNull

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
@@ -23,6 +23,7 @@ public class VaultUsernamePasswordCredentialImpl extends BaseStandardCredentials
 
     public static final String DEFAULT_USERNAME_KEY = "username";
     public static final String DEFAULT_PASSWORD_KEY = "password";
+    public static final Integer DEFAULT_ENGINE_VERSION = 2;
 
     private static final long serialVersionUID = 1L;
 
@@ -35,6 +36,7 @@ public class VaultUsernamePasswordCredentialImpl extends BaseStandardCredentials
     public VaultUsernamePasswordCredentialImpl(CredentialsScope scope, String id,
         String description) {
         super(scope, id, description);
+        setEngineVersion(DEFAULT_ENGINE_VERSION);
     }
 
 


### PR DESCRIPTION
Documentation (as well as when creating from the UI) suggests a default engine version is `2`. When this is not explicitly set we can get a stacktrace similar to: 

```
2020-08-18 05:51:42.583+0000 [id=266470] INFO c.d.j.v.c.c.VaultHelper$SecretRetrieve#call: Retrieving vault secret path=secret/ci/global key=bitbucket_user engineVersion=null
2020-08-18 05:51:42.584+0000 [id=266470] INFO c.d.j.v.c.common.VaultHelper#retrieveVaultCredentials: Retrieving vault credential ID : global_vault_cicd
2020-08-18 05:51:42.584+0000 [id=266470] INFO com.bettercloud.vault.Vault#<init>: Constructing a Vault instance with no provided Engine version, defaulting to version 2.
2020-08-18 05:51:42.655+0000 [id=266470] WARNING o.e.j.s.h.ContextHandler$Context#log: 
 Error while serving https://removed-for-security/job/myjob/descriptorByName/com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource/fillRepositoryItems java.lang.NullPointerException
 at com.bettercloud.vault.api.Logical.read(Logical.java:75
 at com.datapipe.jenkins.vault.VaultAccessor.read(VaultAccessor.java:90)
 at com.datapipe.jenkins.vault.credentials.common.VaultHelper$SecretRetrieve.call(VaultHelper.java:121)
 Caused: java.lang.RuntimeException
 at com.datapipe.jenkins.vault.credentials.common.VaultHelper$SecretRetrieve.call(VaultHelper.java:132)
 at com.datapipe.jenkins.vault.credentials.common.VaultHelper.getVaultSecret(VaultHelper.java:44)
 at com.datapipe.jenkins.vault.credentials.common.VaultUsernamePasswordCredentialImpl.getUsername(VaultUsernamePasswordCredentialImpl.java:89)
 at com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator.<init>(BitbucketUsernamePasswordAuthenticator.java:58)
 at com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticatorSource.convert(BitbucketUsernamePasswordAuthenticatorSource.java:54)
 at com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticatorSource.convert(BitbucketUsernamePasswordAuthenticatorSource.java:36)
 at jenkins.authentication.tokens.api.AuthenticationTokens.convert(AuthenticationTokens.java:148)
 at com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource$DescriptorImpl.doFillRepositoryItems(BitbucketSCMSource.java:1209)
 at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
 at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:396)
 Caused: java.lang.reflect.InvocationTargetException at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:400)
 at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:408)
 at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:212)
```

This situation is remedied by:
- Setting `engineVersion`
- Creating the credential via UI
- Editing engineVersion from the UI and saving to persist the change. 

Of course a user can explicitly call `setEngineVersion(2)` when creating credentials. However, documentation and behavior when creating through the UI suggests that `2` is the default value if nothing is provided. Therefore perhaps it should explicitly be set in accordance with the docs.