### PR TITLE
Namespace and prefix path support on credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ work/
 *.sublime*
 tmp/
 src/test/resources/com/datapipe/jenkins/vault/util/ssl/
+.DS_Store

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
@@ -56,16 +56,15 @@ public abstract class AbstractAuthenticatingVaultTokenCredential extends Abstrac
                 auth.withNameSpace(null);
             }
         }
-        return getToken(vault, auth);
+        return getToken(auth);
     }
 
     /**
      * Authenticate with vault using this credential and return the token. The {@code auth} client
      * will be configured with this credentials namespace.
-     * @param vault vault client
      * @param auth vault auth client
      * @return authentication token
      * @throws VaultPluginException if failed to authenticate with vault
      */
-    protected abstract String getToken(@NonNull Vault vault, @NonNull Auth auth);
+    protected abstract String getToken(@NonNull Auth auth);
 }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
@@ -1,0 +1,71 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.api.Auth;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Abstract Vault token credential that authenticates with the vault server to retrieve the
+ * authentication token. This credential type can explicitly configure the namespace which
+ * the authentication method is mounted.
+ */
+public abstract class AbstractAuthenticatingVaultTokenCredential extends AbstractVaultTokenCredential {
+
+    @CheckForNull
+    private String namespace;
+
+    protected AbstractAuthenticatingVaultTokenCredential(CredentialsScope scope, String id,
+        String description) {
+        super(scope, id, description);
+    }
+
+    /**
+     * Get Vault namespace.
+     * @return vault namespace or null
+     */
+    @CheckForNull
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Set namespace where auth method is mounted. If set to "/"
+     * the root namespace is explicitly forced, otherwise the
+     * namespace from the secret credential vault config is used.
+     * @param namespace vault namespace
+     */
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = Util.fixEmptyAndTrim(namespace);
+    }
+
+    @Override
+    protected final String getToken(Vault vault) {
+        // set authentication namespace if configured for this credential.
+        // importantly, this will not effect the underlying VaultConfig namespace.
+        Auth auth = vault.auth();
+        if (namespace != null) {
+            if (!namespace.trim().equals("/")) {
+                auth.withNameSpace(namespace);
+            } else {
+                auth.withNameSpace(null);
+            }
+        }
+        return getToken(vault, auth);
+    }
+
+    /**
+     * Authenticate with vault using this credential and return the token. The {@code auth} client
+     * will be configured with this credentials namespace.
+     * @param vault vault client
+     * @param auth vault auth client
+     * @return authentication token
+     * @throws VaultPluginException if failed to authenticate with vault
+     */
+    protected abstract String getToken(@NonNull Vault vault, @NonNull Auth auth);
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
@@ -2,21 +2,69 @@ package com.datapipe.jenkins.vault.credentials;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Util;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public abstract class AbstractVaultTokenCredential
     extends BaseStandardCredentials implements VaultCredential {
 
+    @CheckForNull
+    private String namespace;
+
     protected AbstractVaultTokenCredential(CredentialsScope scope, String id, String description) {
         super(scope, id, description);
+    }
+
+    /**
+     * Get Vault namespace.
+     * @return vault namespace or null
+     */
+    @CheckForNull
+    public String getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Set namespace where auth method is mounted. If set to "/"
+     * the root namespace is explicitly forced, otherwise the
+     * namespace from the secret credential vault config is used.
+     * @param namespace vault namespace
+     */
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = Util.fixEmptyAndTrim(namespace);
     }
 
     protected abstract String getToken(Vault vault);
 
     @Override
     public Vault authorizeWithVault(VaultConfig config) {
-        Vault vault = new Vault(config);
-        return new Vault(config.token(getToken(vault)));
+        try {
+            VaultConfig authCfg = config;
+            // override vault credential namespace
+            if (namespace != null) {
+                authCfg = new VaultConfig()
+                    .address(config.getAddress())
+                    .engineVersion(config.getGlobalEngineVersion())
+                    .prefixPathDepth(config.getPrefixPathDepth())
+                    .sslConfig(config.getSslConfig())
+                    .secretsEnginePathMap(config.getSecretsEnginePathMap())
+                    .openTimeout(config.getOpenTimeout())
+                    .readTimeout(config.getReadTimeout());
+                if (!namespace.trim().equals("/")) {
+                    authCfg = authCfg.nameSpace(namespace);
+                }
+                authCfg.build();
+            }
+            String token = getToken(new Vault(authCfg));
+            return new Vault(config.token(token));
+        } catch (VaultException ve) {
+            throw new VaultPluginException("failed to authorize vault credentials", ve);
+        }
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
@@ -2,69 +2,21 @@ package com.datapipe.jenkins.vault.credentials;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
-import com.datapipe.jenkins.vault.exception.VaultPluginException;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
-import hudson.Util;
-import org.kohsuke.stapler.DataBoundSetter;
 
 public abstract class AbstractVaultTokenCredential
     extends BaseStandardCredentials implements VaultCredential {
 
-    @CheckForNull
-    private String namespace;
-
     protected AbstractVaultTokenCredential(CredentialsScope scope, String id, String description) {
         super(scope, id, description);
-    }
-
-    /**
-     * Get Vault namespace.
-     * @return vault namespace or null
-     */
-    @CheckForNull
-    public String getNamespace() {
-        return namespace;
-    }
-
-    /**
-     * Set namespace where auth method is mounted. If set to "/"
-     * the root namespace is explicitly forced, otherwise the
-     * namespace from the secret credential vault config is used.
-     * @param namespace vault namespace
-     */
-    @DataBoundSetter
-    public void setNamespace(String namespace) {
-        this.namespace = Util.fixEmptyAndTrim(namespace);
     }
 
     protected abstract String getToken(Vault vault);
 
     @Override
     public Vault authorizeWithVault(VaultConfig config) {
-        try {
-            VaultConfig authCfg = config;
-            // override vault credential namespace
-            if (namespace != null) {
-                authCfg = new VaultConfig()
-                    .address(config.getAddress())
-                    .engineVersion(config.getGlobalEngineVersion())
-                    .prefixPathDepth(config.getPrefixPathDepth())
-                    .sslConfig(config.getSslConfig())
-                    .secretsEnginePathMap(config.getSecretsEnginePathMap())
-                    .openTimeout(config.getOpenTimeout())
-                    .readTimeout(config.getReadTimeout());
-                if (!namespace.trim().equals("/")) {
-                    authCfg = authCfg.nameSpace(namespace);
-                }
-                authCfg.build();
-            }
-            String token = getToken(new Vault(authCfg));
-            return new Vault(config.token(token));
-        } catch (VaultException ve) {
-            throw new VaultPluginException("failed to authorize vault credentials", ve);
-        }
+        Vault vault = new Vault(config);
+        return new Vault(config.token(getToken(vault)));
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
@@ -2,6 +2,7 @@ package com.datapipe.jenkins.vault.credentials;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -12,7 +13,7 @@ import hudson.util.Secret;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class VaultAppRoleCredential extends AbstractVaultTokenCredential {
+public class VaultAppRoleCredential extends AbstractAuthenticatingVaultTokenCredential {
 
     private final @NonNull
     Secret secretId;
@@ -48,9 +49,9 @@ public class VaultAppRoleCredential extends AbstractVaultTokenCredential {
     }
 
     @Override
-    public String getToken(Vault vault) {
+    public String getToken(Vault vault, Auth auth) {
         try {
-            return vault.auth().loginByAppRole(path, roleId, Secret.toString(secretId))
+            return auth.loginByAppRole(path, roleId, Secret.toString(secretId))
                 .getAuthClientToken();
         } catch (VaultException e) {
             throw new VaultPluginException("could not log in into vault", e);

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
@@ -1,6 +1,5 @@
 package com.datapipe.jenkins.vault.credentials;
 
-import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential.java
@@ -49,7 +49,7 @@ public class VaultAppRoleCredential extends AbstractAuthenticatingVaultTokenCred
     }
 
     @Override
-    public String getToken(Vault vault, Auth auth) {
+    public String getToken(Auth auth) {
         try {
             return auth.loginByAppRole(path, roleId, Secret.toString(secretId))
                 .getAuthClientToken();

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
@@ -2,6 +2,7 @@ package com.datapipe.jenkins.vault.credentials;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -18,7 +19,7 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class VaultGCPCredential extends AbstractVaultTokenCredential {
+public class VaultGCPCredential extends AbstractAuthenticatingVaultTokenCredential {
 
     @NonNull
     private final String role;
@@ -44,7 +45,7 @@ public class VaultGCPCredential extends AbstractVaultTokenCredential {
     }
 
     @Override
-    public String getToken(Vault vault) {
+    public String getToken(Vault vault, Auth auth) {
         String jwt;
         try {
             jwt = retrieveGoogleJWT();
@@ -53,7 +54,7 @@ public class VaultGCPCredential extends AbstractVaultTokenCredential {
         }
 
         try {
-            return vault.withRetries(5, 500).auth().loginByGCP(role, jwt).getAuthClientToken();
+            return auth.loginByGCP(role, jwt).getAuthClientToken();
         } catch (VaultException e) {
             throw new VaultPluginException("could not log in into vault", e);
         }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
@@ -1,6 +1,5 @@
 package com.datapipe.jenkins.vault.credentials;
 
-import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
@@ -38,6 +38,11 @@ public class VaultGCPCredential extends AbstractVaultTokenCredential {
         return role;
     }
 
+    @NonNull
+    public String getAudience() {
+        return audience;
+    }
+
     @Override
     public String getToken(Vault vault) {
         String jwt;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
@@ -45,7 +45,7 @@ public class VaultGCPCredential extends AbstractAuthenticatingVaultTokenCredenti
     }
 
     @Override
-    public String getToken(Vault vault, Auth auth) {
+    public String getToken(Auth auth) {
         String jwt;
         try {
             jwt = retrieveGoogleJWT();

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential.java
@@ -1,6 +1,5 @@
 package com.datapipe.jenkins.vault.credentials;
 
-import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential.java
@@ -32,7 +32,7 @@ public class VaultGithubTokenCredential extends AbstractAuthenticatingVaultToken
     }
 
     @Override
-    public String getToken(Vault vault, Auth auth) {
+    public String getToken(Auth auth) {
         try {
             return auth.loginByGithub(Secret.toString(accessToken)).getAuthClientToken();
         } catch (VaultException e) {

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential.java
@@ -2,6 +2,7 @@ package com.datapipe.jenkins.vault.credentials;
 
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -10,7 +11,7 @@ import hudson.Extension;
 import hudson.util.Secret;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-public class VaultGithubTokenCredential extends AbstractVaultTokenCredential {
+public class VaultGithubTokenCredential extends AbstractAuthenticatingVaultTokenCredential {
 
     // https://www.vaultproject.io/docs/auth/github.html#generate-a-github-personal-access-token
     private final @NonNull
@@ -31,9 +32,9 @@ public class VaultGithubTokenCredential extends AbstractVaultTokenCredential {
     }
 
     @Override
-    public String getToken(Vault vault) {
+    public String getToken(Vault vault, Auth auth) {
         try {
-            return vault.auth().loginByGithub(Secret.toString(accessToken)).getAuthClientToken();
+            return auth.loginByGithub(Secret.toString(accessToken)).getAuthClientToken();
         } catch (VaultException e) {
             throw new VaultPluginException("could not log in into vault", e);
         }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
@@ -1,6 +1,5 @@
 package com.datapipe.jenkins.vault.credentials;
 
-import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsScope;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
@@ -43,6 +43,11 @@ public class VaultKubernetesCredential extends AbstractVaultTokenCredential {
         this.mountPath = mountPath;
     }
 
+    @NonNull
+    public String getRole() {
+        return this.role;
+    }
+
     @Override
     @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
     public String getToken(Vault vault) {
@@ -60,7 +65,7 @@ public class VaultKubernetesCredential extends AbstractVaultTokenCredential {
                 .loginByJwt(mountPath, role, jwt)
                 .getAuthClientToken();
         } catch (VaultException e) {
-            throw new VaultPluginException("could not log in into vault", e);
+            throw new VaultPluginException("could not log in into vault: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential.java
@@ -51,7 +51,7 @@ public class VaultKubernetesCredential extends AbstractAuthenticatingVaultTokenC
 
     @Override
     @SuppressFBWarnings(value = "DMI_HARDCODED_ABSOLUTE_FILENAME")
-    protected String getToken(Vault vault, Auth auth) {
+    protected String getToken(Auth auth) {
         String jwt;
         try (Stream<String> input =  Files.lines(Paths.get(SERVICE_ACCOUNT_TOKEN_PATH)) ) {
             jwt = input.collect(Collectors.joining());

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredential.java
@@ -19,6 +19,10 @@ public class VaultTokenCredential extends AbstractVaultTokenCredential {
         this.token = token;
     }
 
+    @NonNull
+    public Secret getToken() {
+        return token;
+    }
 
     @Override
     public String getToken(Vault vault) {

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
@@ -11,7 +11,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import static com.datapipe.jenkins.vault.credentials.common.VaultHelper.getVaultSecret;
 
 /**
- * Base Vault credentials that contain a {@code path}, {@prefixPath}, {@code namespace},
+ * Base Vault credentials that contain a {@code path}, {@code prefixPath}, {@code namespace},
  * and {@code engineVersion}.
  */
 public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardCredentials {

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
@@ -1,0 +1,89 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import static com.datapipe.jenkins.vault.credentials.common.VaultHelper.getVaultSecret;
+
+/**
+ * Base Vault credentials that contain a {@code path}, {@prefixPath}, {@code namespace},
+ * and {@code engineVersion}.
+ */
+public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardCredentials {
+
+    private String path;
+    private String prefixPath;
+    private String namespace;
+    private Integer engineVersion;
+
+    AbstractVaultBaseStandardCredentials(CredentialsScope scope, String id, String description) {
+        super(scope, id, description);
+    }
+
+    @NonNull
+    public String getPrefixPath() {
+        return prefixPath;
+    }
+
+    @DataBoundSetter
+    public void setPrefixPath(String prefixPath) {
+        this.prefixPath = Util.fixEmptyAndTrim(prefixPath);
+    }
+
+    @NonNull
+    public String getPath() {
+        return path;
+    }
+
+    @DataBoundSetter
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @CheckForNull
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = Util.fixEmptyAndTrim(namespace);
+    }
+
+    @CheckForNull
+    public Integer getEngineVersion() {
+        return engineVersion;
+    }
+
+    @DataBoundSetter
+    public void setEngineVersion(Integer engineVersion) {
+        this.engineVersion = engineVersion;
+    }
+
+    /**
+     * Look up secret key value.
+     * @param key secret key name
+     * @return vault secret value
+     */
+    @NonNull
+    protected String getVaultSecretKeyValue(String key) {
+        String s = getVaultSecret(this.path, key, this.prefixPath, this.namespace, this.engineVersion);
+        if (s == null) {
+            throw new VaultPluginException("Fetching from Vault failed for key '" + key + "'");
+        }
+        return s;
+    }
+
+    /**
+     * Get credential display name. Defaults to secret path.
+     * @return display name
+     */
+    public String getDisplayName() {
+        return this.path;
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -1,7 +1,6 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -46,9 +46,6 @@ public class VaultStringCredentialImpl extends AbstractVaultBaseStandardCredenti
     public Secret getSecret() {
         String k = defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY);
         String s = getVaultSecretKeyValue(k);
-        if (s == null) {
-            throw new VaultPluginException("Fetching from Vault failed for key " + k, null);
-        }
         return Secret.fromString(s);
     }
 

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The default <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> to
+  use for authentication and secrets. Leave blank if namespaces are not enabled or the secret is part of the root
+  namespace.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/credentials.jelly
@@ -10,5 +10,8 @@
   <f:entry title="Path">
     <f:textbox field="path" name="path" default="approle"/>
   </f:entry>
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the mount path
+  is located. If the auth mount path is on the root namespace use "<code>/</code>", if namespace is empty
+  the global namespace or credential namespace will be used if specified.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/credentials.jelly
@@ -7,5 +7,8 @@
   <f:entry title="Audience">
     <f:textbox field="audience" name="audience"/>
   </f:entry>
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the mount path
+  is located. If the auth mount path is on the root namespace use "<code>/</code>", if namespace is empty
+  the global namespace or credential namespace will be used if specified.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/credentials.jelly
@@ -4,5 +4,8 @@
   <f:entry title="Personal Access Token">
     <f:password field="accessToken" name="accessToken"/>
   </f:entry>
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the mount path
+  is located. If the auth mount path is on the root namespace use "<code>/</code>", if namespace is empty
+  the global namespace or credential namespace will be used if specified.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/credentials.jelly
@@ -7,6 +7,9 @@
   <f:entry title="Mount Path">
     <f:textbox field="mountPath" name="mountPath" default="${descriptor.defaultPath}"/>
   </f:entry>
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
 
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the mount path
+  is located. If the auth mount path is on the root namespace use "<code>/</code>", if namespace is empty
+  the global namespace or credential namespace will be used if specified.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredential/credentials.jelly
@@ -4,5 +4,8 @@
   <f:entry title="Token">
     <f:password field="token" name="token"/>
   </f:entry>
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredential/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenCredential/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the mount path
+  is located. If the auth mount path is on the root namespace use "<code>/</code>", if namespace is empty
+  the global namespace or credential namespace will be used if specified.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential/credentials.jelly
@@ -4,5 +4,8 @@
   <f:entry title="Path to file containing token">
     <f:textbox field="filepath" name="filepath"/>
   </f:entry>
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultTokenFileCredential/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the mount path
+  is located. If the auth mount path is on the root namespace use "<code>/</code>", if namespace is empty
+  the global namespace or credential namespace will be used if specified.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/credentials.jelly
@@ -1,6 +1,12 @@
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Prefix Path}" field="prefixPath">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%Path}" field="path">
     <f:textbox/>
   </f:entry>
@@ -19,6 +25,6 @@
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 
   <f:validateButton title="${%Test Vault Secrets retrieval}" progress="${%Testing retrieval of username key...}"
-		method="testConnection" with="path,usernameKey,privateKeyKey,passphraseKey,engineVersion" />
+		method="testConnection" with="path,usernameKey,privateKeyKey,passphraseKey,prefixPath,namespace,engineVersion" />
 
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the
+  secret resides in. Leave blank if namespaces are not enabled or the secret is part of the root
+  namespace.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/help-path.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/help-path.html
@@ -1,0 +1,3 @@
+<div>
+  The Vault secret path. Example "<code>kv/eng/ssh/node1</code>".
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/help-prefixPath.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl/help-prefixPath.html
@@ -1,0 +1,8 @@
+<div>
+  The secret engine prefix path. Use this to identify the path the secret engine (i.e. <code>kv</code>)
+  is mounted to if it is not mounted at the root.
+  <p>
+    For example if the secret path is "<code>team1/kv/database</code>" the prefix path would be "<code>team1/kv</code>".
+    If the secret path is "<code>kv/database</code>" the prefix path can be left blank.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/credentials.jelly
@@ -1,6 +1,12 @@
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Prefix Path}" field="prefixPath">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%Path}" field="path">
     <f:textbox/>
   </f:entry>
@@ -13,6 +19,6 @@
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 
   <f:validateButton title="${%Test Vault Secrets retrieval}" progress="${%Testing retrieval of key...}"
-		method="testConnection" with="path,vaultKey,engineVersion" />
+		method="testConnection" with="path,vaultKey,prefixPath,namespace,engineVersion" />
 
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the
+  secret resides in. Leave blank if namespaces are not enabled or the secret is part of the root
+  namespace.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/help-path.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/help-path.html
@@ -1,0 +1,3 @@
+<div>
+  The Vault secret path. Example "<code>kv/eng/apikey/google</code>".
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/help-prefixPath.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl/help-prefixPath.html
@@ -1,0 +1,8 @@
+<div>
+  The secret engine prefix path. Use this to identify the path the secret engine (i.e. <code>kv</code>)
+  is mounted to if it is not mounted at the root.
+  <p>
+    For example if the secret path is "<code>team1/kv/database</code>" the prefix path would be "<code>team1/kv</code>".
+    If the secret path is "<code>kv/database</code>" the prefix path can be left blank.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/credentials.jelly
@@ -1,6 +1,12 @@
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Prefix Path}" field="prefixPath">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%Path}" field="path">
     <f:textbox/>
   </f:entry>
@@ -16,6 +22,6 @@
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 
   <f:validateButton title="${%Test Vault Secrets retrieval}" progress="${%Testing retrieval of username key...}"
-		method="testConnection" with="path,usernameKey,passwordKey,engineVersion" />
+		method="testConnection" with="path,usernameKey,passwordKey,prefixPath,namespace,engineVersion" />
 
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the
+  secret resides in. Leave blank if namespaces are not enabled or the secret is part of the root
+  namespace.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/help-path.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/help-path.html
@@ -1,0 +1,3 @@
+<div>
+  The Vault secret path. Example "<code>kv/eng/database/app1</code>".
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/help-prefixPath.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl/help-prefixPath.html
@@ -1,0 +1,8 @@
+<div>
+  The secret engine prefix path. Use this to identify the path the secret engine (i.e. <code>kv</code>)
+  is mounted to if it is not mounted at the root.
+  <p>
+    For example if the secret path is "<code>team1/kv/database</code>" the prefix path would be "<code>team1/kv</code>".
+    If the secret path is "<code>kv/database</code>" the prefix path can be left blank.
+  </p>
+</div>

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredentialTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredentialTest.java
@@ -65,7 +65,7 @@ public class AbstractAuthenticatingVaultTokenCredentialTest {
         }
 
         @Override
-        protected String getToken(@NotNull Vault vault, @NotNull Auth auth) {
+        protected String getToken(@NotNull Auth auth) {
             try {
                 return auth.loginByCert().getAuthClientToken();
             } catch (VaultException ve) {

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredentialTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredentialTest.java
@@ -1,0 +1,76 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
+import com.bettercloud.vault.response.AuthResponse;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AbstractAuthenticatingVaultTokenCredentialTest {
+
+    private Vault vault;
+    private Auth auth;
+    private AuthResponse authResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        vault = mock(Vault.class);
+        auth = mock(Auth.class);
+        authResponse = mock(AuthResponse.class);
+        when(vault.auth()).thenReturn(auth);
+        when(auth.withNameSpace(anyString())).thenReturn(auth);
+        when(auth.loginByCert()).thenReturn(authResponse);
+        when(authResponse.getAuthClientToken()).thenReturn("12345");
+    }
+
+    @Test
+    public void nonRootNamespace() {
+        ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
+        cred.setNamespace("foo");
+        assertEquals("12345", cred.getToken(vault));
+        verify(auth).withNameSpace("foo");
+    }
+
+    @Test
+    public void rootNamespace() {
+        ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
+        cred.setNamespace("/");
+        assertEquals("12345", cred.getToken(vault));
+        verify(auth).withNameSpace(null);
+    }
+
+    @Test
+    public void nullNamespace() {
+        ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
+        assertEquals("12345", cred.getToken(vault));
+        verify(auth, never()).withNameSpace(any());
+    }
+
+    static class ExampleVaultTokenCredential extends AbstractAuthenticatingVaultTokenCredential {
+
+        protected ExampleVaultTokenCredential() {
+            super(CredentialsScope.GLOBAL, "test", "");
+        }
+
+        @Override
+        protected String getToken(@NotNull Vault vault, @NotNull Auth auth) {
+            try {
+                return auth.loginByCert().getAuthClientToken();
+            } catch (VaultException ve) {
+                throw new VaultPluginException("failed", ve);
+            }
+        }
+    }
+}

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultTokenCredentialBindingIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultTokenCredentialBindingIT.java
@@ -1,6 +1,5 @@
 package com.datapipe.jenkins.vault.it;
 
-import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultTokenCredentialBindingIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultTokenCredentialBindingIT.java
@@ -1,6 +1,7 @@
 package com.datapipe.jenkins.vault.it;
 
 import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.api.Auth;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.domains.Domain;
@@ -39,7 +40,7 @@ public class VaultTokenCredentialBindingIT {
             @Override
             public void evaluate() throws Throwable {
                 VaultAppRoleCredential c = mock(VaultAppRoleCredential.class);
-                when(c.getToken(any(Vault.class))).thenReturn(token);
+                when(c.getToken(any(Vault.class), any(Auth.class))).thenReturn(token);
                 when(c.getId()).thenReturn(credentialsId);
                 CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
                     .addCredentials(Domain.global(), c);

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultTokenCredentialBindingIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultTokenCredentialBindingIT.java
@@ -40,7 +40,7 @@ public class VaultTokenCredentialBindingIT {
             @Override
             public void evaluate() throws Throwable {
                 VaultAppRoleCredential c = mock(VaultAppRoleCredential.class);
-                when(c.getToken(any(Vault.class), any(Auth.class))).thenReturn(token);
+                when(c.getToken(any(Auth.class))).thenReturn(token);
                 when(c.getId()).thenReturn(credentialsId);
                 CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
                     .addCredentials(Domain.global(), c);


### PR DESCRIPTION
Add "namespace" and "prefixPath" configuration options to all vault credential types (string/username password/ssh).

Add "namespace" configuration option to vault auth credentials to handle case where auth provider is mounted
in a different namespace (i.e. root) than the credential.

Add missing getters on vault credentials so they are
displayed in the ui forms.