### PR TITLE
Able to specify custom mountPath for github token credential

### DIFF
--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/credentials.jelly
@@ -7,5 +7,8 @@
   <f:entry title="${%Namespace}" field="namespace">
     <f:textbox/>
   </f:entry>
+  <f:entry title="Mount Path">
+      <f:textbox field="mountPath" name="mountPath" default="${descriptor.defaultPath}"/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredentialTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredentialTest.java
@@ -1,0 +1,90 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
+import com.bettercloud.vault.response.AuthResponse;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VaultGithubTokenCredentialTest {
+
+    @Test
+    public void shouldSetCustomMountPathIfSpecifiedValueIsValid() {
+
+        VaultGithubTokenCredential vaultGithubTokenCredential = new VaultGithubTokenCredential(
+            CredentialsScope.GLOBAL,
+            "id",
+            "description",
+            null);
+        vaultGithubTokenCredential.setMountPath("custom-path");
+
+        assertEquals("custom-path", vaultGithubTokenCredential.getMountPath());
+    }
+
+    @Test
+    public void shouldSetDefaultMountPathIfEmptyMountPathIsSpecified() {
+
+        VaultGithubTokenCredential vaultGithubTokenCredential = new VaultGithubTokenCredential(
+            CredentialsScope.GLOBAL,
+            "id",
+            "description",
+            null);
+        vaultGithubTokenCredential.setMountPath("");
+
+        assertEquals("github", vaultGithubTokenCredential.getMountPath());
+    }
+
+    @Test
+    public void shouldSetDefaultMountPathIfNullMountPathIsSpecified() {
+
+        VaultGithubTokenCredential vaultGithubTokenCredential = new VaultGithubTokenCredential(
+            CredentialsScope.GLOBAL,
+            "id",
+            "description",
+            null);
+        vaultGithubTokenCredential.setMountPath(null);
+
+        assertEquals("github", vaultGithubTokenCredential.getMountPath());
+    }
+
+    @Test
+    public void shouldSetDefaultMountPathIfWhiteSpaceMountPathIsSpecified() {
+
+        VaultGithubTokenCredential vaultGithubTokenCredential = new VaultGithubTokenCredential(
+            CredentialsScope.GLOBAL,
+            "id",
+            "description",
+            null);
+        vaultGithubTokenCredential.setMountPath("   ");
+
+        assertEquals("github", vaultGithubTokenCredential.getMountPath());
+    }
+
+    @Test
+    public void shouldUseCustomMountPathIfSpecified() throws VaultException {
+
+        VaultGithubTokenCredential vaultGithubTokenCredential = new VaultGithubTokenCredential(
+            CredentialsScope.GLOBAL,
+            "id",
+            "description",
+            null);
+
+        Vault mockVault = mock(Vault.class);
+        Auth mockAuth = mock(Auth.class);
+        AuthResponse mockAuthResponse = mock(AuthResponse.class);
+        String expectedToken = "token";
+        when(mockVault.auth()).thenReturn(mockAuth);
+        when(mockAuth.loginByGithub("", "github")).thenReturn(mockAuthResponse);
+        when(mockAuthResponse.getAuthClientToken()).thenReturn(expectedToken);
+
+        String actualToken = vaultGithubTokenCredential.getToken(mockVault);
+
+        assertEquals(expectedToken, actualToken);
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Dinesh <dineshudt17@gmail.com>

Previously we were using `github` as the mountPath and it is the default value in vault. In this PR, your can choose the custom mount path which is configured in Vault.

<img width="1079" alt="Screenshot 2020-10-03 at 4 44 11 PM" src="https://user-images.githubusercontent.com/13361187/94990212-e380c600-0597-11eb-8d03-70a741c3ad4a.png">

I will update the README if this feature make sense. Thanks