### PR TITLE
Support tokens with expiration while fetching secrets #133

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
@@ -14,7 +14,8 @@ import org.kohsuke.stapler.DataBoundSetter;
  * authentication token. This credential type can explicitly configure the namespace which
  * the authentication method is mounted.
  */
-public abstract class AbstractAuthenticatingVaultTokenCredential extends AbstractVaultTokenCredential {
+public abstract class AbstractAuthenticatingVaultTokenCredential extends
+    AbstractVaultTokenCredentialWithExpiration {
 
     @CheckForNull
     private String namespace;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -1,0 +1,75 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import java.util.Calendar;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public abstract class AbstractVaultTokenCredentialWithExpiration
+    extends AbstractVaultTokenCredential {
+
+    private final static Logger LOGGER = Logger
+        .getLogger(AbstractVaultTokenCredentialWithExpiration.class.getName());
+
+    private Calendar tokenExpiry;
+    private String currentClientToken;
+
+    protected AbstractVaultTokenCredentialWithExpiration(CredentialsScope scope, String id,
+        String description) {
+        super(scope, id, description);
+    }
+
+    protected abstract String getToken(Vault vault);
+
+    @Override
+    public Vault authorizeWithVault(VaultConfig config) {
+        Vault vault = getVault(config);
+        if (tokenExpired()) {
+            currentClientToken = getToken(vault);
+            config.token(currentClientToken);
+            setTokenExpiry(vault);
+        } else {
+            config.token(currentClientToken);
+        }
+        return vault;
+    }
+
+    protected Vault getVault(VaultConfig config) {
+        return new Vault(config);
+    }
+
+    private void setTokenExpiry(Vault vault) {
+        int tokenTTL = 0;
+        try {
+            tokenTTL = (int) vault.auth().lookupSelf().getTTL();
+        } catch (VaultException e) {
+            LOGGER.log(Level.WARNING, "Could not determine token expiration. " +
+                "Check if token is allowed to access auth/token/lookup-self. " +
+                "Assuming token TTL expired.", e);
+        }
+        tokenExpiry = Calendar.getInstance();
+        tokenExpiry.add(Calendar.SECOND, tokenTTL);
+    }
+
+    private boolean tokenExpired() {
+        if (tokenExpiry == null) {
+            return true;
+        }
+
+        boolean result = true;
+        Calendar now = Calendar.getInstance();
+        long timeDiffInMillis = now.getTimeInMillis() - tokenExpiry.getTimeInMillis();
+        if (timeDiffInMillis < -2000L) {
+            // token will be valid for at least another 2s
+            result = false;
+            LOGGER.log(Level.FINE, "Auth token is still valid");
+        } else {
+            LOGGER.log(Level.FINE, "Auth token has to be re-issued" + timeDiffInMillis);
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
@@ -1,0 +1,115 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
+import com.bettercloud.vault.response.AuthResponse;
+import com.bettercloud.vault.response.LookupResponse;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AbstractVaultTokenCredentialWithExpirationTest {
+
+    private Vault vault;
+    private VaultConfig vaultConfig;
+    private Auth auth;
+    private AuthResponse authResponse;
+    private LookupResponse lookupResponse;
+    private ExampleVaultTokenCredentialWithExpiration vaultTokenCredentialWithExpiration;
+
+    @Before
+    public void setUp() throws VaultException {
+        vault = mock(Vault.class);
+        vaultConfig = mock(VaultConfig.class);
+        auth = mock(Auth.class);
+        authResponse = mock(AuthResponse.class);
+        lookupResponse = mock(LookupResponse.class);
+        vaultTokenCredentialWithExpiration = new ExampleVaultTokenCredentialWithExpiration(vault);
+
+        when(vault.auth()).thenReturn(auth);
+        when(auth.loginByCert()).thenReturn(authResponse);
+        when(authResponse.getAuthClientToken()).thenReturn("fakeToken");
+    }
+
+    @Test
+    public void shouldBeAbleToFetchTokenOnInit() throws VaultException {
+        when(auth.lookupSelf()).thenReturn(lookupResponse);
+        when(lookupResponse.getTTL()).thenReturn(5L);
+
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+
+        verify(vaultConfig).token("fakeToken");
+    }
+
+    @Test
+    public void shouldReuseTheExistingTokenIfNotExpired() throws VaultException {
+        when(auth.lookupSelf()).thenReturn(lookupResponse);
+        when(lookupResponse.getTTL()).thenReturn(5L);
+
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+
+        verify(vaultConfig, times(2)).token("fakeToken");
+    }
+
+    @Test
+    public void shouldFetchNewTokenIfExpired() throws VaultException {
+        when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
+        when(auth.lookupSelf()).thenReturn(lookupResponse);
+        when(lookupResponse.getTTL()).thenReturn(0L);
+
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+
+        verify(vaultConfig, times(2)).token(anyString());
+        verify(vaultConfig).token("fakeToken1");
+        verify(vaultConfig).token("fakeToken2");
+    }
+
+    @Test
+    public void shouldExpireTokenImmediatelyIfExceptionFetchingTTL() throws VaultException {
+        when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
+        when(auth.lookupSelf()).thenThrow(new VaultException("Fail for testing"));
+
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+
+        verify(vaultConfig, times(2)).token(anyString());
+        verify(vaultConfig).token("fakeToken1");
+        verify(vaultConfig).token("fakeToken2");
+    }
+
+    static class ExampleVaultTokenCredentialWithExpiration extends
+        AbstractVaultTokenCredentialWithExpiration {
+
+        private final Vault vault;
+
+        protected ExampleVaultTokenCredentialWithExpiration(Vault vault) {
+            super(CredentialsScope.GLOBAL, "id", "description");
+            this.vault = vault;
+        }
+
+        @Override
+        protected Vault getVault(VaultConfig config) {
+            return vault;
+        }
+
+        @Override
+        protected String getToken(Vault vault) {
+            try {
+                return vault.auth().loginByCert().getAuthClientToken();
+            } catch (VaultException e) {
+                throw new VaultPluginException(e.getMessage(), e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the support to store the expiration of the token and use the same token unless it is expired. This will help to reduce number of tokens created by Jenkins Plugin on vault.  This is specially helpful in case of tokens with long TTLs - as getting new token every-time can easily overwhelm the Vault server.

Thanks @dineshba @SrinivasanTarget for help.