### PR TITLE
Added regexp to split CASC_VAULT_PATHS by comma, space and their combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The secret source for JCasC is configured via environment variables as way to ge
 - The environment variable `CASC_VAULT_APPROLE_SECRET` must be present, it token is not used and U/P not used. (Vault AppRole Secret ID.)
 - The environment variable `CASC_VAULT_KUBERNETES_ROLE` must be present, if you want to use Kubernetes Service Account. (Vault Kubernetes Role.)
 - The environment variable `CASC_VAULT_TOKEN` must be present, if U/P is not used. (Vault token.)
-- The environment variable `CASC_VAULT_PATHS` must be present. (Comma separated vault key paths. For example, `secret/jenkins,secret/admin`.)
+- The environment variable `CASC_VAULT_PATHS` must be present. (Comma or space separated vault key paths. For example, `secret/jenkins,secret/admin` or `secret/jenkins secret/admin`.)
 - The environment variable `CASC_VAULT_URL` must be present. (Vault url, including port number.)
 - The environment variable `CASC_VAULT_AGENT_ADDR` is optional. It takes precedence over `CASC_VAULT_URL` and is used for connecting to a Vault Agent. [See this section](#vault-agent)
 - The environment variable `CASC_VAULT_MOUNT` is optional. (Vault auth mount. For example, `ldap` or another username & password authentication type, defaults to `userpass`.)

--- a/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSource.java
+++ b/src/main/java/com/datapipe/jenkins/vault/jcasc/secrets/VaultSecretSource.java
@@ -67,7 +67,7 @@ public class VaultSecretSource extends SecretSource {
             .orElseGet(() -> getVariable(CASC_VAULT_URL));
         Optional<String> vaultNamespace = getVariable(CASC_VAULT_NAMESPACE);
         Optional<String> vaultPrefixPath = getVariable(CASC_VAULT_PREFIX_PATH);
-        Optional<String[]> vaultPaths = getCommaSeparatedVariables(CASC_VAULT_PATHS);
+        Optional<String[]> vaultPaths = getSeparatedVariables(CASC_VAULT_PATHS);
         getVariable(CASC_VAULT_PATH).ifPresent(s -> LOGGER
             .log(Level.SEVERE, "{0} is deprecated, please switch to {1}",
                 new Object[]{CASC_VAULT_PATH, CASC_VAULT_PATHS}));
@@ -227,8 +227,8 @@ public class VaultSecretSource extends SecretSource {
         return Optional.ofNullable(prop.getProperty(key, System.getenv(key)));
     }
 
-    private Optional<String[]> getCommaSeparatedVariables(String key) {
-        return getVariable(key).map(str -> str.split(","));
+    private Optional<String[]> getSeparatedVariables(String key) {
+        return getVariable(key).map(str -> str.split("\\s*(\\s|,)\\s*"));
     }
 
     @Override


### PR DESCRIPTION
To fulfill the following feature request:
https://github.com/jenkinsci/hashicorp-vault-plugin/issues/158