### PR TITLE
Vault access denied should be an exception

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBuildWrapper.java
@@ -190,8 +190,8 @@ public class VaultBuildWrapper extends SimpleBuildWrapper {
         if (restResponse == null) return false;
         int status = restResponse.getStatus();
         if (status == 403) {
-            logger.printf("Access denied to Vault Secrets at '%s'%n", path);
-            return true;
+            throw new VaultPluginException(
+                String.format("Access denied to Vault Secrets at '%s' (hint: set token_num_uses to 0)%n", path));
         } else if (status == 404) {
             if (configuration.getFailIfNotFound()) {
                 throw new VaultPluginException(


### PR DESCRIPTION
Vault secrets being null or empty is an exception.

Access denied results in empty secrets and and therefore the principle of least surprise dictates that the failed secret fetching should fail the build - otherwise user ends up with a build with empty secrets.

Relevant tickets:
- https://github.com/jenkinsci/hashicorp-vault-plugin/issues/162
- https://github.com/jenkinsci/hashicorp-vault-plugin/issues/156

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
