### PR TITLE
Add credential type to authenticate with Google Container Registry

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLogin.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLogin.java
@@ -1,0 +1,22 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+
+@NameWith(value = VaultGCRLogin.NameProvider.class, priority = 32)
+public interface VaultGCRLogin extends VaultUsernamePasswordCredential{
+
+    class NameProvider extends CredentialsNameProvider<VaultGCRLogin> {
+
+        @NonNull
+        @Override
+        public String getName(VaultGCRLogin hashicorpVaultCredentials) {
+            String description = Util.fixEmpty(hashicorpVaultCredentials.getDescription());
+            return hashicorpVaultCredentials.getDisplayName() + (description == null ? ""
+                : " (" + description + ")");
+        }
+    }
+
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl.java
@@ -10,7 +10,7 @@ import hudson.util.Secret;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.json.simple.JSONValue;
+import net.sf.json.JSONObject;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -39,8 +39,7 @@ public class VaultGCRLoginImpl extends AbstractVaultBaseStandardCredentials impl
     @Override
     public Secret getPassword() {
         Map<String, String> s = getVaultSecretValue();
-        String key = JSONValue.toJSONString(s);
-        LOGGER.log(Level.WARNING, "got GCR key '" + key + "' from string '" + s +"' from path '" + this.getPath() + "'");
+        String key = JSONObject.fromObject(s).toString();
         return Secret.fromString(key);
     }
 

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl.java
@@ -1,0 +1,86 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.json.simple.JSONValue;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import static com.datapipe.jenkins.vault.configuration.VaultConfiguration.engineVersions;
+import static com.datapipe.jenkins.vault.credentials.common.VaultHelper.getVaultSecret;
+
+
+
+public class VaultGCRLoginImpl extends AbstractVaultBaseStandardCredentials implements VaultGCRLogin {
+
+    private final static Logger LOGGER = Logger.getLogger(VaultGCRLoginImpl.class.getName());
+
+    @DataBoundConstructor
+    public VaultGCRLoginImpl(CredentialsScope scope, String id,
+        String description) {
+        super(scope, id, description);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Vault Google Container Registry Login";
+    }
+
+    @NonNull
+    @Override
+    public Secret getPassword() {
+        Map<String, String> s = getVaultSecretValue();
+        String key = JSONValue.toJSONString(s);
+        LOGGER.log(Level.WARNING, "got GCR key '" + key + "' from string '" + s +"' from path '" + this.getPath() + "'");
+        return Secret.fromString(key);
+    }
+
+    @NonNull
+    @Override
+    public String getUsername() {
+        return "_json_key";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Vault Google Container Registry Login";
+        }
+
+        public FormValidation doTestConnection(
+            @QueryParameter("path") String path,
+            @QueryParameter("prefixPath") String prefixPath,
+            @QueryParameter("namespace") String namespace,
+            @QueryParameter("engineVersion") Integer engineVersion) {
+
+
+            String okMessage = "Successfully retrieved secret " + path;
+
+            try {
+                getVaultSecret(path, prefixPath, namespace, engineVersion);
+            } catch (Exception e) {
+                return FormValidation.error("FAILED to retrieve Vault secret: \n" + e);
+            }
+
+            return FormValidation
+                .ok(okMessage);
+        }
+
+        @SuppressWarnings("unused") // used by stapler
+        public ListBoxModel doFillEngineVersionItems(@AncestorInPath Item context) {
+            return engineVersions(context);
+        }
+
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl.java
@@ -8,7 +8,6 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.AncestorInPath;

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/credentials.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Prefix Path}" field="prefixPath">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Path}" field="path">
+    <f:textbox/>
+  </f:entry>
+  <f:entry name="engineVersion" title="${%K/V Engine Version}" field="engineVersion">
+    <f:select/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+
+  <f:validateButton title="${%Test Vault Secrets retrieval}" progress="${%Testing retrieval of key...}"
+    method="testConnection" with="path,prefixPath,namespace,engineVersion" />
+
+</j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the
+  secret resides in. Leave blank if namespaces are not enabled or the secret is part of the root
+  namespace.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/help-path.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/help-path.html
@@ -1,0 +1,3 @@
+<div>
+  The Vault secret path. Example "<code>kv/eng/apikey/google</code>".
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/help-prefixPath.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultGCRLoginImpl/help-prefixPath.html
@@ -1,0 +1,8 @@
+<div>
+  The secret engine prefix path. Use this to identify the path the secret engine (i.e. <code>kv</code>)
+  is mounted to if it is not mounted at the root.
+  <p>
+    For example if the secret path is "<code>team1/kv/database</code>" the prefix path would be "<code>team1/kv</code>".
+    If the secret path is "<code>kv/database</code>" the prefix path can be left blank.
+  </p>
+</div>

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultGCRLoginIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultGCRLoginIT.java
@@ -1,0 +1,96 @@
+package com.datapipe.jenkins.vault.it;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.datapipe.jenkins.vault.credentials.common.VaultUsernamePasswordCredential;
+import com.datapipe.jenkins.vault.credentials.common.VaultUsernamePasswordCredentialImpl;
+import hudson.FilePath;
+import hudson.model.Result;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.getShellString;
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.getVariable;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VaultGCRLoginIT {
+
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Test
+    public void shouldRetrieveCorrectCredentialsFromVault() {
+        final String credentialsId = "cloudfoundry";
+        final String vaultAddr = "https://localhost:8200";
+        final String username = "_json_token";
+        final String password = "skywalker";
+        final String jobId = "testJob";
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                VaultUsernamePasswordCredential up = mock(
+                    VaultUsernamePasswordCredentialImpl.class);
+                when(up.getId()).thenReturn(credentialsId);
+                when(up.getUsername()).thenReturn(username);
+                when(up.getPassword()).thenReturn(Secret.fromString(password));
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                    .addCredentials(Domain.global(), up);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobId);
+                p.setDefinition(new CpsFlowDefinition(""
+                    + "node {\n"
+                    + " withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '"
+                    + credentialsId
+                    + "', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) { "
+                    + "      " + getShellString() + " 'echo " + getVariable("USERNAME") + ":" + getVariable("PASSWORD") + " > script'\n"
+                    + "  }\n"
+                    + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(b));
+                story.j.assertLogNotContains(password, b);
+                FilePath script = story.j.jenkins.getWorkspaceFor(p).child("script");
+                assertEquals(username + ":" + password, script.readToString().trim());
+            }
+        });
+    }
+
+    @Test
+    public void shouldFailIfMissingCredentials() {
+        final String credentialsId = "cloudfoundry";
+        final String token = "fakeToken";
+        final String jobId = "testJob";
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                VaultUsernamePasswordCredentialImpl c = new VaultUsernamePasswordCredentialImpl(
+                    null, credentialsId, "Test Credentials");
+                c.setPath("secret/cloudfoundry");
+                c.setUsernameKey(null);
+                c.setPasswordKey(null);
+                c.setEngineVersion(1);
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                    .addCredentials(Domain.global(), c);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobId);
+                p.setDefinition(new CpsFlowDefinition(""
+                    + "node {\n"
+                    + " withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '"
+                    + credentialsId
+                    + "', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) { "
+                    + "      " + getShellString() + " 'echo " + getVariable("USERNAME") + ":" + getVariable("PASSWORD") + " > script'\n"
+                    + "  }\n"
+                    + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b));
+                story.j.assertLogNotContains(token, b);
+                story.j.assertLogContains("credentials", b);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This adds a credential type that can be used to authenticate with GCR when using `docker.withRegistry()` or the `docker` and `dockerfile` agent types.  I'm not sure if this needs some specific documentation to make its use clear how to use.

This builds on top of changes in #178.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
