### PR TITLE
Add optional `required` parameter to VaultSecretValue

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -44,9 +44,11 @@
       <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
       <option name="JD_KEEP_EMPTY_RETURN" value="false" />
     </JavaCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="CSS">
       <indentOptions>

--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -174,7 +174,7 @@ public class VaultAccessor implements Serializable {
                 for (VaultSecretValue value : vaultSecret.getSecretValues()) {
                     String vaultKey = value.getVaultKey();
                     String secret = values.get(vaultKey);
-                    if (StringUtils.isBlank(secret)) {
+                    if (StringUtils.isBlank(secret) && value.getIsRequired()) {
                         throw new IllegalArgumentException(
                             "Vault Secret " + vaultKey + " at " + path
                                 + " is either null or empty. Please check the Secret in Vault.");

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -41,6 +41,7 @@ public class VaultSecretValue
 
     private String envVar;
     private final String vaultKey;
+    private final boolean isRequired;
 
     @Deprecated
     public VaultSecretValue(String envVar, @NonNull String vaultKey) {
@@ -51,6 +52,13 @@ public class VaultSecretValue
     @DataBoundConstructor
     public VaultSecretValue(@NonNull String vaultKey) {
         this.vaultKey = fixEmptyAndTrim(vaultKey);
+        this.isRequired = true;
+    }
+    
+    @DataBoundConstructor
+    public VaultSecretValue(@NonNull String vaultKey, boolean required) {
+        this.vaultKey = fixEmptyAndTrim(vaultKey);
+        this.isRequired = required;
     }
 
     @DataBoundSetter
@@ -70,6 +78,10 @@ public class VaultSecretValue
         return vaultKey;
     }
 
+    public boolean getIsRequired() {
+        return isRequired;
+    }
+    
     @Extension
     public static final class DescriptorImpl
         extends Descriptor<VaultSecretValue> {

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -40,20 +40,18 @@ public class VaultSecretValue
     extends AbstractDescribableImpl<VaultSecretValue> {
 
     private String envVar;
-    private boolean isRequired;
+    private boolean isRequired = DescriptorImpl.DEFAULT_IS_REQUIRED;
     private final String vaultKey;
 
     @Deprecated
     public VaultSecretValue(String envVar, @NonNull String vaultKey) {
         this.envVar = fixEmptyAndTrim(envVar);
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = DescriptorImpl.DEFAULT_IS_REQUIRED;
     }
 
     @DataBoundConstructor
     public VaultSecretValue(@NonNull String vaultKey) {
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = DescriptorImpl.DEFAULT_IS_REQUIRED;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -47,14 +47,15 @@ public class VaultSecretValue
     public VaultSecretValue(String envVar, @NonNull String vaultKey) {
         this.envVar = fixEmptyAndTrim(envVar);
         this.vaultKey = fixEmptyAndTrim(vaultKey);
+        this.isRequired = true; // Old behavior
     }
 
     @DataBoundConstructor
     public VaultSecretValue(@NonNull String vaultKey) {
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = true;
+        this.isRequired = false;
     }
-    
+
     @DataBoundConstructor
     public VaultSecretValue(@NonNull String vaultKey, boolean required) {
         this.vaultKey = fixEmptyAndTrim(vaultKey);
@@ -81,7 +82,7 @@ public class VaultSecretValue
     public boolean getIsRequired() {
         return isRequired;
     }
-    
+
     @Extension
     public static final class DescriptorImpl
         extends Descriptor<VaultSecretValue> {

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -39,8 +39,6 @@ import static hudson.Util.fixEmptyAndTrim;
 public class VaultSecretValue
     extends AbstractDescribableImpl<VaultSecretValue> {
 
-    public final static Boolean DEFAULT_IS_REQUIRED = true;
-
     private String envVar;
     private boolean isRequired;
     private final String vaultKey;
@@ -49,13 +47,13 @@ public class VaultSecretValue
     public VaultSecretValue(String envVar, @NonNull String vaultKey) {
         this.envVar = fixEmptyAndTrim(envVar);
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = DEFAULT_IS_REQUIRED;
+        this.isRequired = DescriptorImpl.DEFAULT_IS_REQUIRED;
     }
 
     @DataBoundConstructor
     public VaultSecretValue(@NonNull String vaultKey) {
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = DEFAULT_IS_REQUIRED;
+        this.isRequired = DescriptorImpl.DEFAULT_IS_REQUIRED;
     }
 
     @DataBoundSetter
@@ -87,6 +85,8 @@ public class VaultSecretValue
     @Extension
     public static final class DescriptorImpl
         extends Descriptor<VaultSecretValue> {
+
+        public final static Boolean DEFAULT_IS_REQUIRED = true;
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -39,6 +39,8 @@ import static hudson.Util.fixEmptyAndTrim;
 public class VaultSecretValue
     extends AbstractDescribableImpl<VaultSecretValue> {
 
+    public final static Boolean DEFAULT_IS_REQUIRED = true;
+
     private String envVar;
     private boolean isRequired;
     private final String vaultKey;
@@ -47,13 +49,13 @@ public class VaultSecretValue
     public VaultSecretValue(String envVar, @NonNull String vaultKey) {
         this.envVar = fixEmptyAndTrim(envVar);
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = true; // Old behavior
+        this.isRequired = DEFAULT_IS_REQUIRED;
     }
 
     @DataBoundConstructor
     public VaultSecretValue(@NonNull String vaultKey) {
         this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = false;
+        this.isRequired = DEFAULT_IS_REQUIRED;
     }
 
     @DataBoundSetter

--- a/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
+++ b/src/main/java/com/datapipe/jenkins/vault/model/VaultSecretValue.java
@@ -40,8 +40,8 @@ public class VaultSecretValue
     extends AbstractDescribableImpl<VaultSecretValue> {
 
     private String envVar;
+    private boolean isRequired;
     private final String vaultKey;
-    private final boolean isRequired;
 
     @Deprecated
     public VaultSecretValue(String envVar, @NonNull String vaultKey) {
@@ -56,15 +56,14 @@ public class VaultSecretValue
         this.isRequired = false;
     }
 
-    @DataBoundConstructor
-    public VaultSecretValue(@NonNull String vaultKey, boolean required) {
-        this.vaultKey = fixEmptyAndTrim(vaultKey);
-        this.isRequired = required;
-    }
-
     @DataBoundSetter
     public void setEnvVar(String envVar) {
         this.envVar = envVar;
+    }
+
+    @DataBoundSetter
+    public void setIsRequired(boolean isRequired) {
+        this.isRequired = isRequired;
     }
 
     /**

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/config.jelly
@@ -9,8 +9,8 @@
     <f:textbox/>
   </f:entry>
 
-  <f:entry title="Required?" field="isRequired">
-    <f:checkbox/>
+  <f:entry field="isRequired">
+    <f:checkbox title="Required?" />
   </f:entry>
 
   <f:entry title="">

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/config.jelly
@@ -9,6 +9,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry title="Required?" field="isRequired">
+    <f:checkbox/>
+  </f:entry>
+
   <f:entry title="">
     <div align="right">
       <f:repeatableDeleteButton/>

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/config.jelly
@@ -10,7 +10,7 @@
   </f:entry>
 
   <f:entry field="isRequired">
-    <f:checkbox title="Required?" />
+    <f:checkbox title="Required?" default="${descriptor.DEFAULT_IS_REQUIRED}" />
   </f:entry>
 
   <f:entry title="">

--- a/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/help-isRequired.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/model/VaultSecretValue/help-isRequired.html
@@ -1,0 +1,4 @@
+<div>
+  A toggle to determine if the given Vault secret value must be present in your secret<br/>
+  If checked, the value is required; the plugin will throw an error if the value is not found in the secret.
+</div>


### PR DESCRIPTION
Add an optional `required` parameter to VaultSecretValues so that secrets can quietly be empty if `required: false` is set.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (N/A)
- [x] Link to relevant pull requests, esp. upstream and downstream changes (N/A)
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Edit: Further explanation
while `failIfNotFound` configuration option exists, this is for handling when a _secret_ is not found. This PR is to more granularly allow optional values within a secret, for example:

```groovy
  def secrets = [
    [
      path: 'some/path/in/vault',
      secretValues: [
       [envVar: 'MANDATORY_THING', vaultKey: 'mandatoryThing', isRequired: true]
       [envVar: 'OPTIONAL_THING', vaultKey: 'optionalThing', isRequired: false],
      ]
    ]
  ]
```