### PR TITLE
fixing the fallback to get the config to access Vault

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/FolderVaultConfiguration.java
@@ -37,17 +37,20 @@ public class FolderVaultConfiguration extends AbstractFolderProperty<AbstractFol
         @NonNull
         @Override
         public VaultConfiguration forJob(@NonNull Item job) {
+            return getVaultConfig(job.getParent());
+        }
+
+        @Override
+        public VaultConfiguration getVaultConfig(@NonNull ItemGroup itemGroup) {
             VaultConfiguration resultingConfig = null;
-            for (ItemGroup g = job.getParent(); g instanceof AbstractFolder;
-                g = ((AbstractFolder) g).getParent()) {
+            for (ItemGroup g = itemGroup; g instanceof AbstractFolder; g = ((AbstractFolder) g).getParent()) {
                 FolderVaultConfiguration folderProperty = ((AbstractFolder<?>) g).getProperties()
-                    .get(FolderVaultConfiguration.class);
+                                                                                 .get(FolderVaultConfiguration.class);
                 if (folderProperty == null) {
                     continue;
                 }
                 if (resultingConfig != null) {
-                    resultingConfig = resultingConfig
-                        .mergeWithParent(folderProperty.getConfiguration());
+                    resultingConfig = resultingConfig.mergeWithParent(folderProperty.getConfiguration());
                 } else {
                     resultingConfig = folderProperty.getConfiguration();
                 }

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/GlobalVaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/GlobalVaultConfiguration.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -50,6 +51,11 @@ public class GlobalVaultConfiguration extends GlobalConfiguration {
         @NonNull
         @Override
         public VaultConfiguration forJob(@NonNull Item job) {
+            return getVaultConfig(job.getParent());
+        }
+
+        @Override
+        public VaultConfiguration getVaultConfig(@NonNull ItemGroup itemGroup) {
             return GlobalVaultConfiguration.get().getConfiguration();
         }
     }

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfigResolver.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfigResolver.java
@@ -3,9 +3,12 @@ package com.datapipe.jenkins.vault.configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionPoint;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 
 public abstract class VaultConfigResolver implements ExtensionPoint {
 
     @NonNull
     public abstract VaultConfiguration forJob(@NonNull Item job);
+
+    public abstract VaultConfiguration getVaultConfig(@NonNull ItemGroup<Item> itemGroup);
 }

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
@@ -28,9 +28,8 @@ import org.kohsuke.stapler.QueryParameter;
 
 import static hudson.Util.fixEmptyAndTrim;
 
-public class VaultConfiguration
-    extends AbstractDescribableImpl<VaultConfiguration>
-    implements Serializable {
+public class VaultConfiguration extends AbstractDescribableImpl<VaultConfiguration>
+                                implements Serializable {
 
     private static final int RETRY_INTERVAL_MILLISECONDS = 1000;
     private static final int DEFAULT_TIMEOUT = 30;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredentialsProvider.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredentialsProvider.java
@@ -1,0 +1,89 @@
+package com.datapipe.jenkins.vault.credentials;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolder;
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider.FolderCredentialsProperty;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.datapipe.jenkins.vault.credentials.common.AbstractVaultBaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.model.ItemGroup;
+import hudson.security.ACL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+
+/**
+ * This class provides the credentials that we need to authenticate against Vault
+ * and the credentials stored in Vault, after assigning the right context to them.
+ *
+ * @author Hassan CHAKROUN {@literal <h.chakrouun@gmail.com> }
+ *
+ */
+@Extension(optional = true, ordinal = 1)
+public class VaultCredentialsProvider extends CredentialsProvider {
+
+    @Override
+    public <C extends Credentials> List<C> getCredentials(Class<C> type, ItemGroup itemGroup, Authentication authentication) {
+        return getCredentials(type, itemGroup, authentication, Collections.emptyList());
+    }
+
+    @NonNull
+    @Override
+    public <C extends Credentials> List<C> getCredentials(@NonNull Class<C> type,
+                                                          @Nullable ItemGroup itemGroup,
+                                                          @Nullable Authentication authentication,
+                                                          @NonNull List<DomainRequirement> domainRequirements) {
+        CredentialsMatcher matcher = (type != VaultCredential.class ?
+                                        CredentialsMatchers.instanceOf(AbstractVaultBaseStandardCredentials.class) :
+                                        CredentialsMatchers.always());
+        List<C> creds = new ArrayList<C>();
+        if (ACL.SYSTEM.equals(authentication)) {
+            for (ItemGroup g = itemGroup; g instanceof AbstractFolder; g = (AbstractFolder.class.cast(g)).getParent()) {
+                FolderCredentialsProperty property = ((AbstractFolder<?>) g).getProperties()
+                                                                           .get(FolderCredentialsProperty.class);
+                if (property == null) {
+                    continue;
+                }
+
+                List<C> folderCreds = DomainCredentials.getCredentials(
+                                                    property.getDomainCredentialsMap(),
+                                                    type,
+                                                    domainRequirements,
+                                                    matcher
+                                                );
+
+                if (type != VaultCredential.class) {
+                    for (C c : folderCreds) {
+                        ((AbstractVaultBaseStandardCredentials)c).setContext(g);
+                    }
+                }
+
+                creds.addAll(folderCreds);
+            }
+
+            List<C> globalCreds = DomainCredentials.getCredentials(
+                                                SystemCredentialsProvider.getInstance().getDomainCredentialsMap(),
+                                                type,
+                                                domainRequirements,
+                                                matcher
+                                            );
+            if (type != VaultCredential.class) {
+                for (C c : globalCreds) {
+                    ((AbstractVaultBaseStandardCredentials)c).setContext(Jenkins.get());
+                }
+            }
+            creds.addAll(globalCreds);
+        }
+
+        return creds;
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
@@ -6,6 +6,7 @@ import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
+import hudson.model.ItemGroup;
 import java.util.Map;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -22,6 +23,7 @@ public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardC
     private String prefixPath;
     private String namespace;
     private Integer engineVersion;
+    private ItemGroup context;
 
     AbstractVaultBaseStandardCredentials(CredentialsScope scope, String id, String description) {
         super(scope, id, description);
@@ -67,6 +69,14 @@ public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardC
         this.engineVersion = engineVersion;
     }
 
+    public void setContext(@NonNull ItemGroup context) {
+        this.context = context;
+    }
+
+    public ItemGroup getContext() {
+        return this.context;
+    }
+
     /**
      * Look up secret key value.
      * @param key secret key name
@@ -74,7 +84,7 @@ public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardC
      */
     @NonNull
     protected String getVaultSecretKeyValue(String key) {
-        String s = getVaultSecretKey(this.path, key, this.prefixPath, this.namespace, this.engineVersion);
+        String s = getVaultSecretKey(this.path, key, this.prefixPath, this.namespace, this.engineVersion, this.context);
         if (s == null) {
             throw new VaultPluginException("Fetching from Vault failed for key '" + key + "'");
         }
@@ -87,7 +97,7 @@ public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardC
      */
     @NonNull
     protected Map<String, String> getVaultSecretValue() {
-        Map<String, String> s = getVaultSecret(this.path, this.prefixPath, this.namespace, this.engineVersion);
+        Map<String, String> s = getVaultSecret(this.path, this.prefixPath, this.namespace, this.engineVersion, this.context);
         if (s == null) {
             throw new VaultPluginException("Fetching from Vault failed for secret '" + this.path + "'");
         }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultFileCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultFileCredentialImpl.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.io.ByteArrayInputStream;
@@ -88,6 +89,7 @@ public class VaultFileCredentialImpl extends AbstractVaultBaseStandardCredential
         }
 
         public FormValidation doTestConnection(
+            @AncestorInPath ItemGroup<Item> context,
             @QueryParameter("path") String path,
             @QueryParameter("useKey") Boolean useKey,
             @QueryParameter("vaultKey") String vaultKey,
@@ -98,21 +100,20 @@ public class VaultFileCredentialImpl extends AbstractVaultBaseStandardCredential
 
             String okMessage = "Successfully retrieved secret " + path;
 
-            try {
-                getVaultSecret(path, prefixPath, namespace, engineVersion);
-            } catch (Exception e) {
-                return FormValidation.error("FAILED to retrieve Vault secret: \n" + e);
-            }
             if(useKey) {
                 try {
-                    getVaultSecretKey(path, vaultKey, prefixPath, namespace, engineVersion);
+                    getVaultSecretKey(path, vaultKey, prefixPath, namespace, engineVersion, context);
                 } catch (Exception e) {
                     return FormValidation.error("FAILED to retrieve key '" + vaultKey + "' Vault secret: \n" + e);
                 }
                 okMessage += " with key " + vaultKey;
+            } else {
+                try {
+                    getVaultSecret(path, prefixPath, namespace, engineVersion, context);
+                } catch (Exception e) {
+                    return FormValidation.error("FAILED to retrieve Vault secret: \n" + e);
+                }
             }
-
-
 
             return FormValidation
                 .ok(okMessage);

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
@@ -7,13 +7,16 @@ import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.matchers.IdMatcher;
 import com.datapipe.jenkins.vault.VaultAccessor;
-import com.datapipe.jenkins.vault.configuration.GlobalVaultConfiguration;
+import com.datapipe.jenkins.vault.configuration.VaultConfigResolver;
 import com.datapipe.jenkins.vault.configuration.VaultConfiguration;
 import com.datapipe.jenkins.vault.credentials.VaultCredential;
 import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
 import hudson.Util;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.remoting.Channel;
 import hudson.security.ACL;
 import java.io.IOException;
@@ -22,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.model.Jenkins;
 import jenkins.security.SlaveToMasterCallable;
 import org.apache.commons.lang.StringUtils;
 
@@ -30,10 +32,14 @@ public class VaultHelper {
 
     private static final Logger LOGGER = Logger.getLogger(VaultHelper.class.getName());
 
-    static Map<String, String> getVaultSecret(@NonNull String secretPath, @CheckForNull String prefixPath, @CheckForNull String namespace, @CheckForNull Integer engineVersion) {
+    static Map<String, String> getVaultSecret(@NonNull String secretPath,
+                                              @CheckForNull String prefixPath,
+                                              @CheckForNull String namespace,
+                                              @CheckForNull Integer engineVersion,
+                                              @NonNull ItemGroup<Item> context) {
         try {
             Map<String, String> values;
-            SecretRetrieve retrieve = new SecretRetrieve(secretPath, prefixPath, namespace, engineVersion);
+            SecretRetrieve retrieve = new SecretRetrieve(secretPath, prefixPath, namespace, engineVersion, context);
 
             Channel channel = Channel.current();
             if (channel == null) {
@@ -48,9 +54,14 @@ public class VaultHelper {
         }
     }
 
-    static String getVaultSecretKey(@NonNull String secretPath, @NonNull String secretKey, @CheckForNull String prefixPath, @CheckForNull String namespace, @CheckForNull Integer engineVersion) {
+    static String getVaultSecretKey(@NonNull String secretPath,
+                                    @NonNull String secretKey,
+                                    @CheckForNull String prefixPath,
+                                    @CheckForNull String namespace,
+                                    @CheckForNull Integer engineVersion,
+                                    @NonNull ItemGroup<Item> context) {
         try {
-            Map<String, String> values = getVaultSecret(secretPath, prefixPath, namespace, engineVersion);
+            Map<String, String> values = getVaultSecret(secretPath, prefixPath, namespace, engineVersion, context);
 
             if (!values.containsKey(secretKey)) {
                 String message = String.format(
@@ -76,19 +87,32 @@ public class VaultHelper {
         private final String namespace;
         @CheckForNull
         private Integer engineVersion;
+        @NonNull
+        private transient ItemGroup<Item> credentialContext;
 
-        SecretRetrieve(String secretPath, String prefixPath, String namespace, Integer engineVersion) {
+        SecretRetrieve(String secretPath, String prefixPath, String namespace, Integer engineVersion, @NonNull ItemGroup<Item> credentialContext) {
             this.secretPath = secretPath;
             this.prefixPath = Util.fixEmptyAndTrim(prefixPath);
             this.namespace = Util.fixEmptyAndTrim(namespace);
             this.engineVersion = engineVersion;
+            this.credentialContext = credentialContext;
         }
 
         @Override
         public Map<String, String> call() throws IOException {
-            GlobalVaultConfiguration globalConfig = GlobalVaultConfiguration.get();
+            if (credentialContext == null) {
+                throw new IllegalStateException("The vault credential need a context");
+            }
 
-            VaultConfiguration configuration = globalConfig.getConfiguration();
+            VaultConfiguration configuration = null;
+            for (VaultConfigResolver resolver : ExtensionList.lookup(VaultConfigResolver.class)) {
+                if (configuration != null) {
+                    configuration = configuration
+                        .mergeWithParent(resolver.getVaultConfig(credentialContext));
+                } else {
+                    configuration = resolver.getVaultConfig(credentialContext);
+                }
+            }
 
             if (configuration == null) {
                 throw new IllegalStateException("Vault plugin has not been configured.");
@@ -116,7 +140,7 @@ public class VaultHelper {
                 }
 
                 VaultCredential vaultCredential = configuration.getVaultCredential();
-                if (vaultCredential == null) vaultCredential = retrieveVaultCredentials(configuration.getVaultCredentialId());
+                if (vaultCredential == null) vaultCredential = retrieveVaultCredentials(configuration.getVaultCredentialId(), credentialContext);
 
                 VaultAccessor vaultAccessor = new VaultAccessor(vaultConfig, vaultCredential);
                 vaultAccessor.setMaxRetries(configuration.getMaxRetries());
@@ -124,8 +148,6 @@ public class VaultHelper {
                 vaultAccessor.init();
 
                 return vaultAccessor.read(secretPath, engineVersion).getData();
-
-
             } catch (VaultPluginException vpe) {
               throw vpe;
             } catch (Exception e) {
@@ -134,7 +156,7 @@ public class VaultHelper {
         }
     }
 
-    private static VaultCredential retrieveVaultCredentials(String id) {
+    private static VaultCredential retrieveVaultCredentials(String id, ItemGroup<Item> itemGroup) {
         if (StringUtils.isBlank(id)) {
             throw new VaultPluginException(
                 "The credential id was not configured - please specify the credentials to use.");
@@ -143,7 +165,7 @@ public class VaultHelper {
         }
         List<VaultCredential> credentials = CredentialsProvider
             .lookupCredentials(VaultCredential.class,
-                Jenkins.get(),
+                itemGroup,
                 ACL.SYSTEM,
                 Collections.<DomainRequirement>emptyList());
         VaultCredential credential = CredentialsMatchers

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -109,6 +110,7 @@ public class VaultSSHUserPrivateKeyImpl extends AbstractVaultBaseStandardCredent
         }
 
         public FormValidation doTestConnection(
+            @AncestorInPath ItemGroup<Item> context,
             @QueryParameter("path") String path,
             @QueryParameter("usernameKey") String usernameKey,
             @QueryParameter("privateKeyKey") String privateKeyKey,
@@ -119,19 +121,19 @@ public class VaultSSHUserPrivateKeyImpl extends AbstractVaultBaseStandardCredent
 
             String username;
             try {
-                username = getVaultSecretKey(path, defaultIfBlank(usernameKey, DEFAULT_USERNAME_KEY), prefixPath, namespace, engineVersion);
+                username = getVaultSecretKey(path, defaultIfBlank(usernameKey, DEFAULT_USERNAME_KEY), prefixPath, namespace, engineVersion, context);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve username key: \n" + e);
             }
 
             try {
-                getVaultSecretKey(path, defaultIfBlank(privateKeyKey, DEFAULT_PRIVATE_KEY_KEY), prefixPath, namespace, engineVersion);
+                getVaultSecretKey(path, defaultIfBlank(privateKeyKey, DEFAULT_PRIVATE_KEY_KEY), prefixPath, namespace, engineVersion, context);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve private key key: \n" + e);
             }
 
             try {
-                getVaultSecretKey(path, defaultIfBlank(passphraseKey, DEFAULT_PASSPHRASE_KEY), prefixPath, namespace, engineVersion);
+                getVaultSecretKey(path, defaultIfBlank(passphraseKey, DEFAULT_PASSPHRASE_KEY), prefixPath, namespace, engineVersion, context);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve passphrase key: \n" + e);
             }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -25,8 +26,7 @@ public class VaultStringCredentialImpl extends AbstractVaultBaseStandardCredenti
     private String vaultKey;
 
     @DataBoundConstructor
-    public VaultStringCredentialImpl(CredentialsScope scope, String id,
-        String description) {
+    public VaultStringCredentialImpl(CredentialsScope scope, String id, String description) {
         super(scope, id, description);
     }
 
@@ -57,6 +57,7 @@ public class VaultStringCredentialImpl extends AbstractVaultBaseStandardCredenti
         }
 
         public FormValidation doTestConnection(
+            @AncestorInPath ItemGroup<Item> context,
             @QueryParameter("path") String path,
             @QueryParameter("vaultKey") String vaultKey,
             @QueryParameter("prefixPath") String prefixPath,
@@ -64,7 +65,7 @@ public class VaultStringCredentialImpl extends AbstractVaultBaseStandardCredenti
             @QueryParameter("engineVersion") Integer engineVersion) {
 
             try {
-                getVaultSecretKey(path, defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY), prefixPath, namespace, engineVersion);
+                getVaultSecretKey(path, defaultIfBlank(vaultKey, DEFAULT_VAULT_KEY), prefixPath, namespace, engineVersion, context);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve Vault secret: \n" + e);
             }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -78,6 +79,7 @@ public class VaultUsernamePasswordCredentialImpl extends AbstractVaultBaseStanda
         }
 
         public FormValidation doTestConnection(
+            @AncestorInPath ItemGroup<Item> context,
             @QueryParameter("path") String path,
             @QueryParameter("usernameKey") String usernameKey,
             @QueryParameter("passwordKey") String passwordKey,
@@ -87,13 +89,13 @@ public class VaultUsernamePasswordCredentialImpl extends AbstractVaultBaseStanda
 
             String username = null;
             try {
-                username = getVaultSecretKey(path, defaultIfBlank(usernameKey, DEFAULT_USERNAME_KEY), prefixPath, namespace, engineVersion);
+                username = getVaultSecretKey(path, defaultIfBlank(usernameKey, DEFAULT_USERNAME_KEY), prefixPath, namespace, engineVersion, context);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve username key: \n" + e);
             }
 
             try {
-                getVaultSecretKey(path, defaultIfBlank(passwordKey, DEFAULT_PASSWORD_KEY), prefixPath, namespace, engineVersion);
+                getVaultSecretKey(path, defaultIfBlank(passwordKey, DEFAULT_PASSWORD_KEY), prefixPath, namespace, engineVersion, context);
             } catch (Exception e) {
                 return FormValidation.error("FAILED to retrieve password key: \n" + e);
             }

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultCertificateCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultCertificateCredentialsImpl/credentials.jelly
@@ -10,11 +10,11 @@
   <f:entry title="${%Path}" field="path">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%KeyStore Key}" field="keyStoreKey" default="keystore">
-    <f:textbox/>
+  <f:entry title="${%KeyStore Key}" field="keyStoreKey">
+    <f:textbox default="${descriptor.DEFAULT_KEYSTORE_KEY}" />
   </f:entry>
-  <f:entry title="${%Password Key}" field="passwordKey" default="password">
-    <f:textbox/>
+  <f:entry title="${%Password Key}" field="passwordKey">
+    <f:textbox default="${descriptor.DEFAULT_PASSWORD_KEY}" />
   </f:entry>
   <f:entry name="engineVersion" title="${%K/V Engine Version}" field="engineVersion">
       <f:select/>


### PR DESCRIPTION
The modifications I introduced in this pull request are about getting the right vault configuration from the right context, so when I fill in the vault config for a multibranch pipeline then I test the retrieval of my secret from vault by the "Test Vault Secrets retrieval" button, It works while before it always using the global configuration because we were missing the credentials' context when we're looking for the vault configuration.
Now, the "Test Vault Secrets retrieval" button and the pipelines (Jenkinsfile) use the right vault config as they look for it in the right order in the chain (From pipeline => possible parents (folder Item) ==> Jenkins global config).

I also added those lines in: https://github.com/jenkinsci/hashicorp-vault-plugin/pull/195/commits/ae364e20666fdfa3f47598483865ea00c6f91c49#diff-400f26e4312f4dd4af5c888bba9019f1ef6db32fb9186de9a619b151ac115b3eR254 , so we can define a **VAULT_ADDR** env variable in the Jenkins global configuration (**Global properties** > **Environment variables** section) so that we can use it whenever the vault address is never defined, and it is available as normal environment variable in Jenkinsfiles.

I also want to mention that the **KeyStore Key** field of **Vault Certificate Credential** is not saved when saving the credential, It is the default value **keystore** that is always used, so I made some changes to the jelly template **https://github.com/jenkinsci/hashicorp-vault-plugin/pull/195/files#diff-3caead88055864dfe6bb98fdec2389f054f16220bd9148b2a3644e11ec4cf1baR14** to show it to the user as a default value so he can use it as a key of a certificate in Vault.

This pull request:
 - Closes #191 
 - Closes #124 
 - Closes #134 

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
