### PR TITLE
Ensure ssh private key ends with newline

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyBinding.java
@@ -67,7 +67,6 @@ public class VaultSSHUserPrivateKeyBinding extends
         StringBuilder contents = new StringBuilder();
         for (String key : sshKey.getPrivateKeys()) {
             contents.append(key);
-            contents.append('\n');
         }
         keyFile.write(contents.toString(), "UTF-8");
         if (launcher.isUnix()) {

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
@@ -90,7 +90,10 @@ public class VaultSSHUserPrivateKeyImpl extends AbstractVaultBaseStandardCredent
     @NonNull
     @Override
     public List<String> getPrivateKeys() {
-        return Collections.singletonList(getPrivateKey());
+        String key = getPrivateKey();
+        // ensure keys end with newline to match the reference implementation
+        // https://github.com/jenkinsci/ssh-credentials-plugin/blob/d141a312701bc9a04de18ac9f97dffdbae19f978/src/main/java/com/cloudbees/jenkins/plugins/sshcredentials/impl/BasicSSHUserPrivateKey.java#L177
+        return Collections.singletonList(key.endsWith("\n") ? key : key + "\n");
     }
 
     @NonNull


### PR DESCRIPTION
SSH private keys should end with a newline. This update ensures that the private
keys returned by the vault SSHUserPrivateKey implementation end with newlines
just like the reference implementation does. If the secret value in vault does not
have a newline it will result in an error when attempting to use the rendered key file:

```
[ssh-agent] Using credentials **** (**** ssh credentials)
[ssh-agent] Looking for ssh-agent implementation...
[ssh-agent]   Exec ssh-agent (binary ssh-agent on a remote machine)
$ ssh-agent
SSH_AUTH_SOCK=/tmp/ssh-fYTrdIvAKCqI/agent.317
SSH_AGENT_PID=319
Running ssh-add (command line suppressed)
Error loading key "/home/jenkins/workspace/tools/test-vault-ssh-key@tmp/private_key_2757282350355641480.key": invalid format
```

Vault users can add a newline to the vault secret value as a current workaround.

There doesn't appear to be a good way to test impl classes due to the dependency on the static VaultHelper.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
