### PR TITLE
[JENKINS-65972] Use SecretPatterns API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/hashicorp-vault-plugin/master)](https://ci.jenkins.io/job/Plugins/job/hashicorp-vault-plugin/job/master/)
 # Jenkins Vault Plugin
+
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/hashicorp-vault-plugin/master)](https://ci.jenkins.io/job/Plugins/job/hashicorp-vault-plugin/job/master/)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/hashicorp-vault-plugin.svg)](https://plugins.jenkins.io/hashicorp-vault-plugin)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/hashicorp-vault-plugin.svg?label=release)](https://github.com/jenkinsci/hashicorp-vault-plugin/releases/latest)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/hashicorp-vault-plugin.svg?color=blue)](https://plugins.jenkins.io/hashicorp-vault-plugin)
 
 This plugin adds a build wrapper to set environment variables from a HashiCorp [Vault](https://www.vaultproject.io/) secret. Secrets are generally masked in the build log, so you can't accidentally print them.  
 It also has the ability to inject Vault credentials into a build pipeline or freestyle job for fine-grained vault interactions.

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultTokenCredentialBinding.java
@@ -101,7 +101,10 @@ public class VaultTokenCredentialBinding extends MultiBinding<AbstractVaultToken
         Map<String, String> m = new HashMap<>();
         m.put(addrVariable, vaultAddr);
         m.put(namespaceVariable, vaultNamespace);
-        m.put(tokenVariable, getToken(credentials));
+        String token = getToken(credentials);
+        // don't add null token variable, can cause NPE in places where credential bindings impls
+        // are not expecting null env var values.
+        m.put(tokenVariable, StringUtils.defaultString(token));
         return new MultiEnvironment(m);
     }
 


### PR DESCRIPTION
Use SecretPatterns API introduced in credentials-binding-plugin 1.26. Bumped
the jenkins version and bom import to 2.303.x to pull in the required
plugin dependency version.

Refs: JENKINS-65972

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
