### PR TITLE
Adds support for using job-specific policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This is just a short introduction, please refer to [Hashicorp itself](https://ww
 
 ### Isolating policies for different jobs
 It may be desirable to have jobs or folders with separate Vault policies allocated. This may be done
-with the optional `policies` configuration option combined with AppRole authentication. The workflow
-would look like this:
+with the optional `policies` configuration option combined with authentication such as the AppRole
+credential. The process is the following:
 * The Jenkins job attempts to retrieve a secret from Vault
 * The AppRole authentication is used to retrieve a new token (if the old one has not expired yet)
 * The Vault plugin then uses the `policies` configuration value with job info to come up with a list of policies
@@ -34,8 +34,9 @@ would look like this:
 
 The policies list may be templatized with values that can come from each job in order to customize
 policies per job or folder. See the `policies` configuration help for more information on available
-tokens to use in the configuration. Please note that the AppRole should have all policies configured
-as `token_policies` and not `identity_policies`, as job-specific tokens inherit all
+tokens to use in the configuration. The `Limit Token Policies` option must also be enabled on the
+auth credential. Please note that the AppRole (or other authentication method) should have all policies
+configured as `token_policies` and not `identity_policies`, as job-specific tokens inherit all
 `identity_policies` automatically.  
 
 ### What about other backends?

--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ When registering the approle backend you can set a couple of different parameter
 * many more
 
 This is just a short introduction, please refer to [Hashicorp itself](https://www.vaultproject.io/docs/auth/approle.html) to get detailed information.
+
+### Isolating policies for different jobs
+It may be desirable to have jobs or folders with separate Vault policies allocated. This may be done
+with the optional `policies` configuration option combined with AppRole authentication. The workflow
+would look like this:
+* The Jenkins job attempts to retrieve a secret from Vault
+* The AppRole authentication is used to retrieve a new token (if the old one has not expired yet)
+* The Vault plugin then uses the `policies` configuration value with job info to come up with a list of policies
+* If this list is not empty, the AppRole token is used to retrieve a new token that only has the specified policies applied
+* This token is then used for all Vault plugin operations in the job
+
+The policies list may be templatized with values that can come from each job in order to customize
+policies per job or folder. See the `policies` configuration help for more information on available
+tokens to use in the configuration. Please note that the AppRole should have all policies configured
+as `token_policies` and not `identity_policies`, as job-specific tokens inherit all
+`identity_policies` automatically.  
+
 ### What about other backends?
 Hashicorp explicitly recommends the AppRole Backend for machine-to-machine authentication. Token based auth is mainly supported for backward compatibility.
 Other backends that might make sense are the AWS EC2 backend, the Azure backend, and the Kubernetes backend. But we do not support these yet. Feel free to contribute!

--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -27,6 +27,7 @@ import hudson.security.ACL;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,7 @@ public class VaultAccessor implements Serializable {
 
     private VaultConfig config;
     private VaultCredential credential;
+    private List<String> policies;
     private int maxRetries = 0;
     private int retryIntervalMilliseconds = 1000;
 
@@ -63,7 +65,7 @@ public class VaultAccessor implements Serializable {
             if (credential == null) {
                 vault = new Vault(config);
             } else {
-                vault = credential.authorizeWithVault(config);
+                vault = credential.authorizeWithVault(config, policies);
             }
 
             vault.withRetries(maxRetries, retryIntervalMilliseconds);
@@ -87,6 +89,14 @@ public class VaultAccessor implements Serializable {
 
     public void setCredential(VaultCredential credential) {
         this.credential = credential;
+    }
+
+    public List<String> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(List<String> policies) {
+        this.policies = policies;
     }
 
     public int getMaxRetries() {
@@ -130,6 +140,38 @@ public class VaultAccessor implements Serializable {
         }
     }
 
+    public static String replacePolicyTokens(String policy, EnvVars envVars) {
+        if (!policy.contains("{")) {
+            return policy;
+        }
+        String jobName = envVars.get("JOB_NAME");
+        String jobBaseName = envVars.get("JOB_BASE_NAME");
+        String folder = "";
+        if (!jobName.equals(jobBaseName) && jobName.contains("/")) {
+            String[] jobElements = jobName.split("/");
+            folder = Arrays.stream(jobElements)
+                .limit(jobElements.length - 1)
+                .collect(Collectors.joining("/"));
+        }
+        return policy
+            .replaceAll("\\{job_base_name}", jobBaseName)
+            .replaceAll("\\{job_name}", jobName)
+            .replaceAll("\\{job_name_us}", jobName.replaceAll("/", "_"))
+            .replaceAll("\\{job_folder}", folder)
+            .replaceAll("\\{job_folder_us}", folder.replaceAll("/", "_"))
+            .replaceAll("\\{node_name}", envVars.get("NODE_NAME"));
+    }
+
+    public static List<String> generatePolicies(String policies, EnvVars envVars) {
+        if (StringUtils.isBlank(policies)) {
+            return null;
+        }
+        return Arrays.stream(policies.split("\n"))
+            .filter(StringUtils::isNotBlank)
+            .map(policy -> replacePolicyTokens(policy.trim(), envVars))
+            .collect(Collectors.toList());
+    }
+
     public static Map<String, String> retrieveVaultSecrets(Run<?,?> run, PrintStream logger, EnvVars envVars, VaultAccessor vaultAccessor, VaultConfiguration initialConfiguration, List<VaultSecret> vaultSecrets) {
         Map<String, String> overrides = new HashMap<>();
 
@@ -156,6 +198,7 @@ public class VaultAccessor implements Serializable {
         }
         vaultAccessor.setConfig(vaultConfig);
         vaultAccessor.setCredential(credential);
+        vaultAccessor.setPolicies(generatePolicies(config.getPolicies(), envVars));
         vaultAccessor.setMaxRetries(config.getMaxRetries());
         vaultAccessor.setRetryIntervalMilliseconds(config.getRetryIntervalMilliseconds());
         vaultAccessor.init();

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
@@ -50,6 +50,8 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
 
     private String prefixPath;
 
+    private String policies;
+
     private Integer timeout = DEFAULT_TIMEOUT;
 
     @DataBoundConstructor
@@ -73,6 +75,7 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         this.engineVersion = toCopy.engineVersion;
         this.vaultNamespace = toCopy.vaultNamespace;
         this.prefixPath = toCopy.prefixPath;
+        this.policies = toCopy.policies;
         this.timeout = toCopy.timeout;
     }
 
@@ -98,6 +101,9 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         }
         if (StringUtils.isBlank(result.getPrefixPath())) {
             result.setPrefixPath(parent.getPrefixPath());
+        }
+        if (StringUtils.isBlank(result.getPolicies())) {
+            result.setPolicies(parent.getPolicies());
         }
         if (result.timeout == null) {
             result.setTimeout(parent.getTimeout());
@@ -181,6 +187,15 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
     @DataBoundSetter
     public void setPrefixPath(String prefixPath) {
         this.prefixPath = fixEmptyAndTrim(prefixPath);
+    }
+
+    public String getPolicies() {
+        return policies;
+    }
+
+    @DataBoundSetter
+    public void setPolicies(String policies) {
+        this.policies = fixEmptyAndTrim(policies);;
     }
 
     public Integer getTimeout() {

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
@@ -52,6 +52,8 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
 
     private String policies;
 
+    private Boolean disableChildPoliciesOverride;
+
     private Integer timeout = DEFAULT_TIMEOUT;
 
     @DataBoundConstructor
@@ -76,6 +78,7 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         this.vaultNamespace = toCopy.vaultNamespace;
         this.prefixPath = toCopy.prefixPath;
         this.policies = toCopy.policies;
+        this.disableChildPoliciesOverride = toCopy.disableChildPoliciesOverride;
         this.timeout = toCopy.timeout;
     }
 
@@ -102,7 +105,8 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         if (StringUtils.isBlank(result.getPrefixPath())) {
             result.setPrefixPath(parent.getPrefixPath());
         }
-        if (StringUtils.isBlank(result.getPolicies())) {
+        if (StringUtils.isBlank(result.getPolicies()) ||
+                (parent.getDisableChildPoliciesOverride() != null && parent.getDisableChildPoliciesOverride())) {
             result.setPolicies(parent.getPolicies());
         }
         if (result.timeout == null) {
@@ -195,7 +199,16 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
 
     @DataBoundSetter
     public void setPolicies(String policies) {
-        this.policies = fixEmptyAndTrim(policies);;
+        this.policies = fixEmptyAndTrim(policies);
+    }
+
+    public Boolean getDisableChildPoliciesOverride() {
+        return disableChildPoliciesOverride;
+    }
+
+    @DataBoundSetter
+    public void setDisableChildPoliciesOverride(Boolean disableChildPoliciesOverride) {
+        this.disableChildPoliciesOverride = disableChildPoliciesOverride;
     }
 
     public Integer getTimeout() {

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredential.java
@@ -46,7 +46,7 @@ public abstract class AbstractAuthenticatingVaultTokenCredential extends
     }
 
     @Override
-    protected final String getToken(Vault vault) {
+    protected Auth getVaultAuth(@NonNull Vault vault) {
         // set authentication namespace if configured for this credential.
         // importantly, this will not effect the underlying VaultConfig namespace.
         Auth auth = vault.auth();
@@ -57,7 +57,12 @@ public abstract class AbstractAuthenticatingVaultTokenCredential extends
                 auth.withNameSpace(null);
             }
         }
-        return getToken(auth);
+        return auth;
+    }
+
+    @Override
+    protected final String getToken(Vault vault) {
+        return getToken(getVaultAuth(vault));
     }
 
     /**

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
@@ -4,6 +4,7 @@ import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import java.util.List;
 
 public abstract class AbstractVaultTokenCredential
     extends BaseStandardCredentials implements VaultCredential {
@@ -15,7 +16,7 @@ public abstract class AbstractVaultTokenCredential
     protected abstract String getToken(Vault vault);
 
     @Override
-    public Vault authorizeWithVault(VaultConfig config) {
+    public Vault authorizeWithVault(VaultConfig config, List<String> policies) {
         Vault vault = new Vault(config);
         return new Vault(config.token(getToken(vault)));
     }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -3,36 +3,102 @@ package com.datapipe.jenkins.vault.credentials;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import com.bettercloud.vault.api.Auth;
+import com.bettercloud.vault.api.Auth.TokenRequest;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public abstract class AbstractVaultTokenCredentialWithExpiration
     extends AbstractVaultTokenCredential {
 
-    private final static Logger LOGGER = Logger
+    protected final static Logger LOGGER = Logger
         .getLogger(AbstractVaultTokenCredentialWithExpiration.class.getName());
 
-    private Calendar tokenExpiry;
-    private String currentClientToken;
+    private Map<String, Calendar> tokenExpiry;
+    private Map<String, String> tokenCache;
 
     protected AbstractVaultTokenCredentialWithExpiration(CredentialsScope scope, String id,
         String description) {
         super(scope, id, description);
+        tokenExpiry = new HashMap<>();
+        tokenCache = new HashMap<>();
     }
 
     protected abstract String getToken(Vault vault);
 
+    /**
+     * Retrieve the Vault auth client. May be overridden in subclasses.
+     * @param vault the Vault instance
+     * @return the Vault auth client
+     */
+    protected Auth getVaultAuth(@NonNull Vault vault) {
+        return vault.auth();
+    }
+
+    /**
+     * Retrieves a new token with specific policies if a list of requested policies is provided.
+     * @param vault the vault instance
+     * @param policies the policies list
+     * @return the new token or null if no policies are defined
+     */
+    protected String getTokenWithPolicies(Vault vault, List<String> policies) {
+        if (policies == null || policies.isEmpty()) {
+            return null;
+        }
+        Auth auth = getVaultAuth(vault);
+        try {
+            TokenRequest tokenRequest = (new TokenRequest()).polices(policies);
+            LOGGER.log(Level.FINE, "Requesting child token with policies {0}",
+                new Object[] {policies});
+            return auth.createToken(tokenRequest).getAuthClientToken();
+        } catch (VaultException e) {
+            throw new VaultPluginException("Could not retrieve token with policies from vault", e);
+        }
+    }
+
+    /**
+     * Retrieves a key to be used for the token cache based on a list of policies.
+     * @param policies the list of policies
+     * @return the key to use for the map, either an empty string or a comma-separated list of policies
+     */
+    private String getCacheKey(List<String> policies) {
+        if (policies == null || policies.isEmpty()) {
+            return "";
+        }
+        return String.join(",", policies);
+    }
+
     @Override
-    public Vault authorizeWithVault(VaultConfig config) {
+    public Vault authorizeWithVault(VaultConfig config, List<String> policies) {
+        // Upgraded instances can have these not initialized in the constructor (serialized jobs possibly)
+        if (tokenCache == null) {
+            tokenCache = new HashMap<>();
+            tokenExpiry = new HashMap<>();
+        }
+
+        String cacheKey = getCacheKey(policies);
         Vault vault = getVault(config);
-        if (tokenExpired()) {
-            currentClientToken = getToken(vault);
-            config.token(currentClientToken);
-            setTokenExpiry(vault);
+        if (tokenExpired(cacheKey)) {
+            tokenCache.put(cacheKey, getToken(vault));
+            config.token(tokenCache.get(cacheKey));
+
+            // After current token is configured, try to retrieve a new child token with limited policies
+            String childToken = getTokenWithPolicies(vault, policies);
+            if (childToken != null) {
+                // A new token was generated, put it in the cache and configure vault
+                tokenCache.put(cacheKey, childToken);
+                config.token(childToken);
+            }
+            setTokenExpiry(vault, cacheKey);
         } else {
-            config.token(currentClientToken);
+            config.token(tokenCache.get(cacheKey));
         }
         return vault;
     }
@@ -41,33 +107,36 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         return new Vault(config);
     }
 
-    private void setTokenExpiry(Vault vault) {
+    private void setTokenExpiry(Vault vault, String cacheKey) {
         int tokenTTL = 0;
         try {
-            tokenTTL = (int) vault.auth().lookupSelf().getTTL();
+            tokenTTL = (int) getVaultAuth(vault).lookupSelf().getTTL();
         } catch (VaultException e) {
-            LOGGER.log(Level.WARNING, "Could not determine token expiration. " +
-                "Check if token is allowed to access auth/token/lookup-self. " +
+            LOGGER.log(Level.WARNING, "Could not determine token expiration for policies '" +
+                cacheKey + "'. Check if token is allowed to access auth/token/lookup-self. " +
                 "Assuming token TTL expired.", e);
         }
-        tokenExpiry = Calendar.getInstance();
-        tokenExpiry.add(Calendar.SECOND, tokenTTL);
+        Calendar expiry = Calendar.getInstance();
+        expiry.add(Calendar.SECOND, tokenTTL);
+        tokenExpiry.put(cacheKey, expiry);
     }
 
-    private boolean tokenExpired() {
-        if (tokenExpiry == null) {
+    private boolean tokenExpired(String cacheKey) {
+        Calendar expiry = tokenExpiry.get(cacheKey);
+        if (expiry == null) {
             return true;
         }
 
         boolean result = true;
         Calendar now = Calendar.getInstance();
-        long timeDiffInMillis = now.getTimeInMillis() - tokenExpiry.getTimeInMillis();
+        long timeDiffInMillis = now.getTimeInMillis() - expiry.getTimeInMillis();
         if (timeDiffInMillis < -10000L) {
             // token will be valid for at least another 10s
             result = false;
-            LOGGER.log(Level.FINE, "Auth token is still valid");
+            LOGGER.log(Level.FINE, "Auth token is still valid for policies '" + cacheKey + "'");
         } else {
-            LOGGER.log(Level.FINE, "Auth token has to be re-issued" + timeDiffInMillis);
+            LOGGER.log(Level.FINE,"Auth token has to be re-issued for policies '" + cacheKey +
+                    "' (" + timeDiffInMillis + "ms difference)");
         }
 
         return result;

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredential.java
@@ -7,11 +7,12 @@ import com.cloudbees.plugins.credentials.NameWith;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serializable;
+import java.util.List;
 
 @NameWith(VaultCredential.NameProvider.class)
 public interface VaultCredential extends StandardCredentials, Serializable {
 
-    Vault authorizeWithVault(VaultConfig config);
+    Vault authorizeWithVault(VaultConfig config, List<String> policies);
 
     class NameProvider extends CredentialsNameProvider<VaultCredential> {
 

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
@@ -17,6 +17,9 @@
     <f:entry field="engineVersion" title="K/V Engine Version">
       <f:select/>
     </f:entry>
+    <f:entry title="(Optional) Job Policies" field="policies">
+      <f:textarea/>
+    </f:entry>
     <f:entry title="Fail if path is not found" field="failIfNotFound">
       <f:checkbox default="${descriptor.DEFAULT_FAIL_NOT_FOUND}"/>
     </f:entry>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
@@ -20,6 +20,9 @@
     <f:entry title="(Optional) Job Policies" field="policies">
       <f:textarea/>
     </f:entry>
+    <f:entry title="(Optional) Disable Policies Override" field="disableChildPoliciesOverride">
+      <f:checkbox/>
+    </f:entry>
     <f:entry title="Fail if path is not found" field="failIfNotFound">
       <f:checkbox default="${descriptor.DEFAULT_FAIL_NOT_FOUND}"/>
     </f:entry>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-disableChildPoliciesOverride.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-disableChildPoliciesOverride.html
@@ -1,0 +1,4 @@
+<div>
+  If set, this will disable any child folder or job from overriding the job policies.
+  This prevents the escalation of privileges by subfolders or jobs.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-policies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-policies.html
@@ -1,0 +1,39 @@
+<div>
+  The Vault policies to use when requesting a token for a job, separated by newlines. If left empty,
+  this will use all policies from the configured authentication. This is useful for
+  AppRole authentication where the AppRole can have many policies attached it and divide
+  up the policies per job based on the job folder or name. This allows you to restrict access on
+  specific jobs or folders. Each policy can use the following tokens to templatize the policies:
+  <ul>
+    <li>{job_base_name} - equal to the JOB_BASE_NAME env var</li>
+    <li>{job_name} - equal to the JOB_NAME env var</li>
+    <li>{job_name_us} - same as {job_name} with slashes converted to underscores</li>
+    <li>{job_folder} - the folder of the job (JOB_NAME - JOB_BASE_NAME without the trailing slash)</li>
+    <li>{job_folder_us} - same as {job_folder} with slashes converted to underscores</li>
+    <li>{node_name} - equal to the NODE_NAME env var</li>
+  </ul>
+
+  For example, a policy list such as:
+  <ul>
+    <li>pol_jenkins_base</li>
+    <li>pol_jenkins_job_base_{job_base_name}</li>
+    <li>pol_jenkins_folder_us_{job_name_folder_us}</li>
+    <li>pol_jenkins/folder/{job_folder}</li>
+    <li>pol_jenkins_job_us_{job_name_us}</li>
+    <li>pol_jenkins/job/{job_name}</li>
+  </ul>
+
+  Would result in six policies being applied to each job run. If the JOB_NAME was
+  "folder1/folder2/job1" and the JOB_BASE_NAME was "job1", the policies applied would be:
+  <ul>
+    <li>pol_jenkins_base</li>
+    <li>pol_jenkins_job_base_job1</li>
+    <li>pol_jenkins_folder_us_folder1_folder2</li>
+    <li>pol_jenkins/folder/folder1/folder2</li>
+    <li>pol_jenkins_job_us_folder1_folder2_job1</li>
+    <li>pol_jenkins/job/folder1/folder2/job1</li>
+  </ul>
+
+  Please note that the AppRole should have all policies configured as token_policies and not
+  identity_policies, as job-specific tokens inherit all identity_policies automatically.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-policies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-policies.html
@@ -5,22 +5,22 @@
   up the policies per job based on the job folder or name. This allows you to restrict access on
   specific jobs or folders. Each policy can use the following tokens to templatize the policies:
   <ul>
-    <li>{job_base_name} - equal to the JOB_BASE_NAME env var</li>
-    <li>{job_name} - equal to the JOB_NAME env var</li>
-    <li>{job_name_us} - same as {job_name} with slashes converted to underscores</li>
-    <li>{job_folder} - the folder of the job (JOB_NAME - JOB_BASE_NAME without the trailing slash)</li>
-    <li>{job_folder_us} - same as {job_folder} with slashes converted to underscores</li>
-    <li>{node_name} - equal to the NODE_NAME env var</li>
+    <li>${job_base_name} - equal to the JOB_BASE_NAME env var</li>
+    <li>${job_name} - equal to the JOB_NAME env var</li>
+    <li>${job_name_us} - same as ${job_name} with slashes converted to underscores</li>
+    <li>${job_folder} - the folder of the job (JOB_NAME - JOB_BASE_NAME without the trailing slash)</li>
+    <li>${job_folder_us} - same as ${job_folder} with slashes converted to underscores</li>
+    <li>${node_name} - equal to the NODE_NAME env var</li>
   </ul>
 
   For example, a policy list such as:
   <ul>
     <li>pol_jenkins_base</li>
-    <li>pol_jenkins_job_base_{job_base_name}</li>
-    <li>pol_jenkins_folder_us_{job_name_folder_us}</li>
-    <li>pol_jenkins/folder/{job_folder}</li>
-    <li>pol_jenkins_job_us_{job_name_us}</li>
-    <li>pol_jenkins/job/{job_name}</li>
+    <li>pol_jenkins_job_base_${job_base_name}</li>
+    <li>pol_jenkins_folder_us_${job_name_folder_us}</li>
+    <li>pol_jenkins/folder/${job_folder}</li>
+    <li>pol_jenkins_job_us_${job_name_us}</li>
+    <li>pol_jenkins/job/${job_name}</li>
   </ul>
 
   Would result in six policies being applied to each job run. If the JOB_NAME was

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/credentials.jelly
@@ -13,5 +13,8 @@
   <f:entry title="${%Namespace}" field="namespace">
     <f:textbox/>
   </f:entry>
+  <f:entry field="usePolicies" title="Limit Token Policies">
+    <f:checkbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/help-usePolicies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAppRoleCredential/help-usePolicies.html
@@ -1,0 +1,5 @@
+<div>
+  If checked and policies are defined in the Vault plugin configuration, a child token will be
+  provisioned after authenticating with Vault with only the configured policies. See the Vault
+  plugin configuration policies for more information.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAwsIamCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAwsIamCredential/credentials.jelly
@@ -13,6 +13,9 @@
   <f:entry title="${%Namespace}" field="namespace">
     <f:textbox/>
   </f:entry>
+  <f:entry field="usePolicies" title="Limit Token Policies">
+    <f:checkbox/>
+  </f:entry>
 
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAwsIamCredential/help-usePolicies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultAwsIamCredential/help-usePolicies.html
@@ -1,0 +1,5 @@
+<div>
+  If checked and policies are defined in the Vault plugin configuration, a child token will be
+  provisioned after authenticating with Vault with only the configured policies. See the Vault
+  plugin configuration policies for more information.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/credentials.jelly
@@ -10,5 +10,8 @@
   <f:entry title="${%Namespace}" field="namespace">
     <f:textbox/>
   </f:entry>
+  <f:entry field="usePolicies" title="Limit Token Policies">
+    <f:checkbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/help-usePolicies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGCPCredential/help-usePolicies.html
@@ -1,0 +1,5 @@
+<div>
+  If checked and policies are defined in the Vault plugin configuration, a child token will be
+  provisioned after authenticating with Vault with only the configured policies. See the Vault
+  plugin configuration policies for more information.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/credentials.jelly
@@ -10,5 +10,8 @@
   <f:entry title="Mount Path">
       <f:textbox field="mountPath" name="mountPath" default="${descriptor.defaultPath}"/>
   </f:entry>
+  <f:entry field="usePolicies" title="Limit Token Policies">
+    <f:checkbox/>
+  </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/help-usePolicies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultGithubTokenCredential/help-usePolicies.html
@@ -1,0 +1,5 @@
+<div>
+  If checked and policies are defined in the Vault plugin configuration, a child token will be
+  provisioned after authenticating with Vault with only the configured policies. See the Vault
+  plugin configuration policies for more information.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/credentials.jelly
@@ -10,6 +10,9 @@
   <f:entry title="${%Namespace}" field="namespace">
     <f:textbox/>
   </f:entry>
+  <f:entry field="usePolicies" title="Limit Token Policies">
+    <f:checkbox/>
+  </f:entry>
 
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/help-usePolicies.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/VaultKubernetesCredential/help-usePolicies.html
@@ -1,0 +1,5 @@
+<div>
+  If checked and policies are defined in the Vault plugin configuration, a child token will be
+  provisioned after authenticating with Vault with only the configured policies. See the Vault
+  plugin configuration policies for more information.
+</div>

--- a/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 public class VaultAccessorTest {
 
     private static final String POLICIES_STR =
-        "\npol1\n\nbase_{job_base_name}\njob/{job_name}\n job_{job_name_us}\nfolder/{job_folder}\nfolder_{job_folder_us}\nnode_{node_name}\n";
+        "\npol1\n\nbase_${job_base_name}\njob/${job_name}\n job_${job_name_us}\nfolder/${job_folder}\nfolder_${job_folder_us}\nnode_${node_name}\n";
 
     @Test
     public void testGeneratePolicies() {

--- a/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
@@ -1,0 +1,44 @@
+package com.datapipe.jenkins.vault;
+
+import hudson.EnvVars;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VaultAccessorTest {
+
+    private static final String POLICIES_STR =
+        "\npol1\n\nbase_{job_base_name}\njob/{job_name}\n job_{job_name_us}\nfolder/{job_folder}\nfolder_{job_folder_us}\nnode_{node_name}\n";
+
+    @Test
+    public void testGeneratePolicies() {
+        EnvVars envVars = mock(EnvVars.class);
+        when(envVars.get("JOB_NAME")).thenReturn("job1");
+        when(envVars.get("JOB_BASE_NAME")).thenReturn("job1");
+        when(envVars.get("NODE_NAME")).thenReturn("node1");
+
+        List<String> policies = VaultAccessor.generatePolicies(POLICIES_STR, envVars);
+        assertThat(policies, equalTo(Arrays.asList(
+            "pol1", "base_job1", "job/job1", "job_job1", "folder/", "folder_", "node_node1"
+        )));
+    }
+
+    @Test
+    public void testGeneratePoliciesWithFolder() {
+        EnvVars envVars = mock(EnvVars.class);
+        when(envVars.get("JOB_NAME")).thenReturn("folder1/folder2/job1");
+        when(envVars.get("JOB_BASE_NAME")).thenReturn("job1");
+        when(envVars.get("NODE_NAME")).thenReturn("node1");
+
+        List<String> policies = VaultAccessor.generatePolicies(POLICIES_STR, envVars);
+        assertThat(policies, equalTo(Arrays.asList(
+            "pol1", "base_job1", "job/folder1/folder2/job1", "job_folder1_folder2_job1",
+            "folder/folder1/folder2", "folder_folder1_folder2", "node_node1"
+        )));
+    }
+}

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredentialTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractAuthenticatingVaultTokenCredentialTest.java
@@ -35,6 +35,14 @@ public class AbstractAuthenticatingVaultTokenCredentialTest {
     }
 
     @Test
+    public void nonRootNamespaceFromGetVaultAuth() {
+        ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
+        cred.setNamespace("foo");
+        Auth authRet = cred.getVaultAuth(vault);
+        verify(authRet).withNameSpace("foo");
+    }
+
+    @Test
     public void nonRootNamespace() {
         ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
         cred.setNamespace("foo");

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
@@ -158,6 +158,7 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         protected ExampleVaultTokenCredentialWithExpiration(Vault vault) {
             super(CredentialsScope.GLOBAL, "id", "description");
             this.vault = vault;
+            this.setUsePolicies(true);
         }
 
         @Override

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
@@ -4,14 +4,20 @@ import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import com.bettercloud.vault.api.Auth;
+import com.bettercloud.vault.api.Auth.TokenRequest;
 import com.bettercloud.vault.response.AuthResponse;
 import com.bettercloud.vault.response.LookupResponse;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,22 +28,27 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
     private Vault vault;
     private VaultConfig vaultConfig;
     private Auth auth;
-    private AuthResponse authResponse;
+    private AuthResponse authResponse, childAuthResponse;
     private LookupResponse lookupResponse;
     private ExampleVaultTokenCredentialWithExpiration vaultTokenCredentialWithExpiration;
+    private List<String> policies;
 
     @Before
     public void setUp() throws VaultException {
+        policies = Arrays.asList("pol1", "pol2");
         vault = mock(Vault.class);
         vaultConfig = mock(VaultConfig.class);
         auth = mock(Auth.class);
         authResponse = mock(AuthResponse.class);
+        childAuthResponse = mock(AuthResponse.class);
+        when(auth.createToken(any(TokenRequest.class))).thenReturn(childAuthResponse);
         lookupResponse = mock(LookupResponse.class);
         vaultTokenCredentialWithExpiration = new ExampleVaultTokenCredentialWithExpiration(vault);
 
         when(vault.auth()).thenReturn(auth);
         when(auth.loginByCert()).thenReturn(authResponse);
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken");
+        when(childAuthResponse.getAuthClientToken()).thenReturn("childToken");
     }
 
     @Test
@@ -45,34 +56,85 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(5L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
 
         verify(vaultConfig).token("fakeToken");
     }
 
     @Test
+    public void shouldFetchNewTokenForDifferentPolicies() throws VaultException {
+        when(auth.lookupSelf()).thenReturn(lookupResponse);
+        when(lookupResponse.getTTL()).thenReturn(5L);
+        when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
+        when(childAuthResponse.getAuthClientToken()).thenReturn("childToken1", "childToken2");
+
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        verify(vaultConfig).token("fakeToken1");
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        verify(vaultConfig).token("childToken1");
+    }
+
+    @Test
+    public void shouldNotFetchChildTokenIfEmptyPoliciesSpecified() throws VaultException {
+        when(authResponse.getAuthClientToken()).thenReturn("fakeToken");
+        when(auth.lookupSelf()).thenReturn(lookupResponse);
+        when(lookupResponse.getTTL()).thenReturn(0L);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, new ArrayList<>());
+
+        verify(vaultConfig, times(1)).token(anyString());
+        verify(vaultConfig).token("fakeToken");
+    }
+
+    @Test
+    public void shouldFetchChildTokenIfPoliciesSpecified() throws VaultException {
+        TokenRequest tokenRequest = (new TokenRequest()).polices(policies);
+        when(auth.createToken(argThat((TokenRequest tr) -> tokenRequest.getPolices() == policies)))
+            .thenReturn(childAuthResponse);
+        when(auth.lookupSelf()).thenReturn(lookupResponse);
+        when(lookupResponse.getTTL()).thenReturn(0L);
+
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+
+        verify(vaultConfig, times(2)).token(anyString());
+        verify(vaultConfig).token("fakeToken");
+        verify(vaultConfig).token("childToken");
+    }
+
+    @Test
     public void shouldReuseTheExistingTokenIfNotExpired() throws VaultException {
+        when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
+        when(childAuthResponse.getAuthClientToken()).thenReturn("childToken1", "childToken2");
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(5L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        verify(vaultConfig, times(2)).token("fakeToken1");
 
-        verify(vaultConfig, times(2)).token("fakeToken");
+        // Different policies results in a new token
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        verify(vaultConfig, times(2)).token("childToken1");
     }
 
     @Test
     public void shouldFetchNewTokenIfExpired() throws VaultException {
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
+        when(childAuthResponse.getAuthClientToken()).thenReturn("childToken1", "childToken2");
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(0L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
-
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
         verify(vaultConfig, times(2)).token(anyString());
         verify(vaultConfig).token("fakeToken1");
         verify(vaultConfig).token("fakeToken2");
+
+        // Different policies results in a new token
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        verify(vaultConfig).token("childToken1");
+        verify(vaultConfig).token("childToken2");
     }
 
     @Test
@@ -80,8 +142,8 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
         when(auth.lookupSelf()).thenThrow(new VaultException("Fail for testing"));
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
 
         verify(vaultConfig, times(2)).token(anyString());
         verify(vaultConfig).token("fakeToken1");

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
@@ -87,11 +87,12 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
 
     @Test
     public void shouldFetchChildTokenIfPoliciesSpecified() throws VaultException {
-        TokenRequest tokenRequest = (new TokenRequest()).polices(policies);
-        when(auth.createToken(argThat((TokenRequest tr) -> tokenRequest.getPolices() == policies)))
-            .thenReturn(childAuthResponse);
+        when(auth.createToken(argThat((TokenRequest tr) ->
+            tr.getPolices() == policies && tr.getTtl().equals("30s")
+        ))).thenReturn(childAuthResponse);
         when(auth.lookupSelf()).thenReturn(lookupResponse);
-        when(lookupResponse.getTTL()).thenReturn(0L);
+        // First response is for parent, second is for child
+        when(lookupResponse.getTTL()).thenReturn(30L, 0L);
 
         vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
 

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
@@ -106,7 +106,7 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
         when(childAuthResponse.getAuthClientToken()).thenReturn("childToken1", "childToken2");
         when(auth.lookupSelf()).thenReturn(lookupResponse);
-        when(lookupResponse.getTTL()).thenReturn(5L);
+        when(lookupResponse.getTTL()).thenReturn(30L);
 
         vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
         vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
@@ -51,6 +51,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -430,7 +431,7 @@ public class VaultConfigurationIT {
         when(cred.getDescription()).thenReturn("description");
         when(cred.getRoleId()).thenReturn("role-id-" + credentialId);
         when(cred.getSecretId()).thenReturn(Secret.fromString("secret-id-" + credentialId));
-        when(cred.authorizeWithVault(any())).thenReturn(vault);
+        when(cred.authorizeWithVault(any(), eq(null))).thenReturn(vault);
         return cred;
 
     }

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
@@ -4,12 +4,14 @@ import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.rest.RestResponse;
+import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.datapipe.jenkins.vault.VaultAccessor;
 import com.datapipe.jenkins.vault.VaultBuildWrapper;
+import com.datapipe.jenkins.vault.configuration.FolderVaultConfiguration;
 import com.datapipe.jenkins.vault.configuration.GlobalVaultConfiguration;
 import com.datapipe.jenkins.vault.configuration.VaultConfiguration;
 import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential;
@@ -49,6 +51,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -153,6 +157,33 @@ public class VaultConfigurationIT {
         return isWindows() ? "%" + v + "%" : "$" + v;
     }
 
+    private void assertOverridePolicies(String globalPolicies, Boolean globalDisableOverride, Boolean folderDisableOverride,
+        String policiesResult) throws Exception {
+        VaultConfiguration globalConfig = GlobalVaultConfiguration.get().getConfiguration();
+        globalConfig.setPolicies(globalPolicies);
+        globalConfig.setDisableChildPoliciesOverride(globalDisableOverride);
+
+        Folder folder = jenkins.createProject(Folder.class, "sub1");
+        VaultConfiguration folderConfig = new VaultConfiguration();
+        folderConfig.setPolicies("folder-policies");
+        folderConfig.setDisableChildPoliciesOverride(folderDisableOverride);
+        folder.addProperty(new FolderVaultConfiguration(folderConfig));
+
+        FreeStyleProject project = folder.createProject(FreeStyleProject.class, "test");
+        FreeStyleBuild build = mock(FreeStyleBuild.class);
+        when(build.getParent()).thenReturn(project);
+        VaultConfiguration vaultConfig = new VaultConfiguration();
+        vaultConfig.setPolicies("job-policies");
+
+        assertThat(VaultAccessor.pullAndMergeConfiguration(build, vaultConfig).getPolicies(),
+            equalTo(policiesResult));
+    }
+
+    private void assertOverridePolicies(Boolean globalDisableOverride, Boolean folderDisableOverride,
+        String policiesResult) throws Exception {
+        assertOverridePolicies("global-policies", globalDisableOverride, folderDisableOverride, policiesResult);
+    }
+
     @Test
     public void shouldUseGlobalConfiguration() throws Exception {
         List<VaultSecret> secrets = standardSecrets();
@@ -221,6 +252,27 @@ public class VaultConfigurationIT {
         verify(mockAccessor, times(1)).read("secret/path1", GLOBAL_ENGINE_VERSION_2);
         jenkins.assertLogContains("echo ****", build);
         jenkins.assertLogNotContains("some-secret", build);
+        assertThat(VaultAccessor.pullAndMergeConfiguration(build, vaultConfig).getPolicies(), nullValue());
+    }
+
+    @Test
+    public void shouldUseJobConfigurationWithoutDisableOverrides() throws Exception {
+        assertOverridePolicies(false, false, "job-policies");
+    }
+
+    @Test
+    public void shouldUseFolderConfigurationWithDisableOverrides() throws Exception {
+        assertOverridePolicies(false, true, "folder-policies");
+    }
+
+    @Test
+    public void shouldUseGlobalConfigurationWithDisableOverrides() throws Exception {
+        assertOverridePolicies(true, false, "global-policies");
+    }
+
+    @Test
+    public void shouldUseEmptyGlobalConfigurationWithDisableOverrides() throws Exception {
+        assertOverridePolicies(null, true, true, null);
     }
 
     @Test


### PR DESCRIPTION
Fixes #214 

This adds support for separating job policies as described in #214. This is inspired by the [Salt integration](https://docs.saltproject.io/en/latest/ref/modules/all/salt.modules.vault.html) and their usage of per-minion policies. The vault plugin may be configured with optional "policies" that may be templatized with tokens that are unique to the job. This allows more isolation of job permissions in Vault, thereby allowing for more secure Jenkins configurations.

I was able to add most of the logic for this functionality into the expiring credential base class. I also had to separate the cached token value by the list of policies specified so that different lists of policies resulted in new tokens. I have tested this on our Jenkins environment and it has allowed me to completely separate the policies of two jobs so that they can only read specific paths in Vault. I also added unit testing for all functionality I added (AFAIK, let me know if there is any missing).

I opted for two configuration options instead of a single one, since in our environment we need to migrate from one method to the other (i.e. AppRole based auth that has all permissions vs AppRole based auth that enables using the limited tokens). This is done in a separate commit in case there are disagreements if this should be how it is configured or not. Without this option, as soon as I enabled policies in the folder or global configuration, the existing auth method no longer worked properly. This may not be useful outside of our use case, so please let me know if I need to remove it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
