### PR TITLE
Ensure vault access only takes place from the controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,10 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
@@ -89,18 +89,18 @@ public class VaultHelper {
     }
 
     static String getVaultSecretKey(@NonNull String secretPath,
-            @NonNull String secretKey,
-            @CheckForNull String prefixPath,
-            @CheckForNull String namespace,
-            @CheckForNull Integer engineVersion,
-            @NonNull ItemGroup<Item> context) {
+                                    @NonNull String secretKey,
+                                    @CheckForNull String prefixPath,
+                                    @CheckForNull String namespace,
+                                    @CheckForNull Integer engineVersion,
+                                    @NonNull ItemGroup<Item> context) {
         try {
             Map<String, String> values = getVaultSecret(secretPath, prefixPath, namespace, engineVersion, context);
 
             if (!values.containsKey(secretKey)) {
                 String message = String.format(
-                        "Key %s could not be found in path %s",
-                        secretKey, secretPath);
+                    "Key %s could not be found in path %s",
+                    secretKey, secretPath);
                 throw new VaultPluginException(message);
             }
 
@@ -113,17 +113,17 @@ public class VaultHelper {
     private static VaultCredential retrieveVaultCredentials(String id, ItemGroup<Item> itemGroup) {
         if (StringUtils.isBlank(id)) {
             throw new VaultPluginException(
-                    "The credential id was not configured - please specify the credentials to use.");
+                "The credential id was not configured - please specify the credentials to use.");
         } else {
             LOGGER.log(Level.INFO, "Retrieving vault credential ID : " + id);
         }
         List<VaultCredential> credentials = CredentialsProvider
-                .lookupCredentials(VaultCredential.class,
-                        itemGroup,
-                        ACL.SYSTEM,
-                        Collections.<DomainRequirement>emptyList());
+            .lookupCredentials(VaultCredential.class,
+                itemGroup,
+                ACL.SYSTEM,
+                Collections.<DomainRequirement>emptyList());
         VaultCredential credential = CredentialsMatchers
-                .firstOrNull(credentials, new IdMatcher(id));
+            .firstOrNull(credentials, new IdMatcher(id));
 
         if (credential == null) {
             throw new CredentialsUnavailableException(id);

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
@@ -14,18 +14,14 @@ import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
-import hudson.Util;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
-import hudson.remoting.Channel;
 import hudson.security.ACL;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.security.SlaveToMasterCallable;
 import org.apache.commons.lang.StringUtils;
 
 public class VaultHelper {
@@ -37,36 +33,74 @@ public class VaultHelper {
                                               @CheckForNull String namespace,
                                               @CheckForNull Integer engineVersion,
                                               @NonNull ItemGroup<Item> context) {
-        try {
-            Map<String, String> values;
-            SecretRetrieve retrieve = new SecretRetrieve(secretPath, prefixPath, namespace, engineVersion, context);
-
-            Channel channel = Channel.current();
-            if (channel == null) {
-                values = retrieve.call();
+        VaultConfiguration configuration = null;
+        for (VaultConfigResolver resolver : ExtensionList.lookup(VaultConfigResolver.class)) {
+            if (configuration != null) {
+                configuration = configuration
+                        .mergeWithParent(resolver.getVaultConfig(context));
             } else {
-                values = channel.call(retrieve);
+                configuration = resolver.getVaultConfig(context);
+            }
+        }
+
+        if (configuration == null) {
+            throw new IllegalStateException("Vault plugin has not been configured.");
+        }
+
+        configuration.fixDefaults();
+        if (engineVersion == null) {
+            engineVersion = configuration.getEngineVersion();
+        }
+
+        String msg = String.format(
+                "Retrieving vault secret path=%s engineVersion=%s",
+                secretPath, engineVersion);
+        LOGGER.info(msg);
+
+        try {
+            VaultConfig vaultConfig = configuration.getVaultConfig();
+
+            if (prefixPath != null) {
+                vaultConfig.prefixPath(prefixPath);
             }
 
-            return values;
-        } catch (IOException | InterruptedException e) {
-            throw new IllegalStateException(e);
+            if (namespace != null) {
+                vaultConfig.nameSpace(namespace);
+            }
+
+            VaultCredential vaultCredential = configuration.getVaultCredential();
+            if (vaultCredential == null)
+                vaultCredential = retrieveVaultCredentials(
+                        configuration.getVaultCredentialId(), context);
+
+            VaultAccessor vaultAccessor = new VaultAccessor(vaultConfig, vaultCredential);
+            vaultAccessor.setMaxRetries(configuration.getMaxRetries());
+            vaultAccessor.setRetryIntervalMilliseconds(
+                    configuration.getRetryIntervalMilliseconds());
+            vaultAccessor.init();
+
+            return vaultAccessor.read(secretPath, engineVersion).getData();
+        } catch (VaultPluginException vpe) {
+            throw vpe;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
+
     }
 
     static String getVaultSecretKey(@NonNull String secretPath,
-                                    @NonNull String secretKey,
-                                    @CheckForNull String prefixPath,
-                                    @CheckForNull String namespace,
-                                    @CheckForNull Integer engineVersion,
-                                    @NonNull ItemGroup<Item> context) {
+            @NonNull String secretKey,
+            @CheckForNull String prefixPath,
+            @CheckForNull String namespace,
+            @CheckForNull Integer engineVersion,
+            @NonNull ItemGroup<Item> context) {
         try {
             Map<String, String> values = getVaultSecret(secretPath, prefixPath, namespace, engineVersion, context);
 
             if (!values.containsKey(secretKey)) {
                 String message = String.format(
-                    "Key %s could not be found in path %s",
-                    secretKey, secretPath);
+                        "Key %s could not be found in path %s",
+                        secretKey, secretPath);
                 throw new VaultPluginException(message);
             }
 
@@ -76,100 +110,20 @@ public class VaultHelper {
         }
     }
 
-    private static class SecretRetrieve extends SlaveToMasterCallable<Map<String, String>, IOException> {
-
-        private static final long serialVersionUID = 1L;
-
-        private final String secretPath;
-        @CheckForNull
-        private final String prefixPath;
-        @CheckForNull
-        private final String namespace;
-        @CheckForNull
-        private Integer engineVersion;
-        @NonNull
-        private transient ItemGroup<Item> credentialContext;
-
-        SecretRetrieve(String secretPath, String prefixPath, String namespace, Integer engineVersion, @NonNull ItemGroup<Item> credentialContext) {
-            this.secretPath = secretPath;
-            this.prefixPath = Util.fixEmptyAndTrim(prefixPath);
-            this.namespace = Util.fixEmptyAndTrim(namespace);
-            this.engineVersion = engineVersion;
-            this.credentialContext = credentialContext;
-        }
-
-        @Override
-        public Map<String, String> call() throws IOException {
-            if (credentialContext == null) {
-                throw new IllegalStateException("The vault credential need a context");
-            }
-
-            VaultConfiguration configuration = null;
-            for (VaultConfigResolver resolver : ExtensionList.lookup(VaultConfigResolver.class)) {
-                if (configuration != null) {
-                    configuration = configuration
-                        .mergeWithParent(resolver.getVaultConfig(credentialContext));
-                } else {
-                    configuration = resolver.getVaultConfig(credentialContext);
-                }
-            }
-
-            if (configuration == null) {
-                throw new IllegalStateException("Vault plugin has not been configured.");
-            }
-
-            configuration.fixDefaults();
-            if (engineVersion == null) {
-                engineVersion = configuration.getEngineVersion();
-            }
-
-            String msg = String.format(
-                "Retrieving vault secret path=%s engineVersion=%s",
-                secretPath, engineVersion);
-            LOGGER.info(msg);
-
-            try {
-                VaultConfig vaultConfig = configuration.getVaultConfig();
-
-                if (prefixPath != null) {
-                    vaultConfig.prefixPath(prefixPath);
-                }
-
-                if (namespace != null) {
-                    vaultConfig.nameSpace(namespace);
-                }
-
-                VaultCredential vaultCredential = configuration.getVaultCredential();
-                if (vaultCredential == null) vaultCredential = retrieveVaultCredentials(configuration.getVaultCredentialId(), credentialContext);
-
-                VaultAccessor vaultAccessor = new VaultAccessor(vaultConfig, vaultCredential);
-                vaultAccessor.setMaxRetries(configuration.getMaxRetries());
-                vaultAccessor.setRetryIntervalMilliseconds(configuration.getRetryIntervalMilliseconds());
-                vaultAccessor.init();
-
-                return vaultAccessor.read(secretPath, engineVersion).getData();
-            } catch (VaultPluginException vpe) {
-              throw vpe;
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
     private static VaultCredential retrieveVaultCredentials(String id, ItemGroup<Item> itemGroup) {
         if (StringUtils.isBlank(id)) {
             throw new VaultPluginException(
-                "The credential id was not configured - please specify the credentials to use.");
+                    "The credential id was not configured - please specify the credentials to use.");
         } else {
             LOGGER.log(Level.INFO, "Retrieving vault credential ID : " + id);
         }
         List<VaultCredential> credentials = CredentialsProvider
-            .lookupCredentials(VaultCredential.class,
-                itemGroup,
-                ACL.SYSTEM,
-                Collections.<DomainRequirement>emptyList());
+                .lookupCredentials(VaultCredential.class,
+                        itemGroup,
+                        ACL.SYSTEM,
+                        Collections.<DomainRequirement>emptyList());
         VaultCredential credential = CredentialsMatchers
-            .firstOrNull(credentials, new IdMatcher(id));
+                .firstOrNull(credentials, new IdMatcher(id));
 
         if (credential == null) {
             throw new CredentialsUnavailableException(id);


### PR DESCRIPTION
Removes the `SecretRetrieve` class that allowed agents to access vault.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

