### PR TITLE
Fix the 'Test Vault Secrets retrieval' Button

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultHelper.java
@@ -60,11 +60,11 @@ public class VaultHelper {
         try {
             VaultConfig vaultConfig = configuration.getVaultConfig();
 
-            if (prefixPath != null) {
+            if (prefixPath != null && ! prefixPath.isEmpty()) {
                 vaultConfig.prefixPath(prefixPath);
             }
 
-            if (namespace != null) {
+            if (namespace != null && ! namespace.isEmpty()) {
                 vaultConfig.nameSpace(namespace);
             }
 


### PR DESCRIPTION
Part of the change in #228 broke the 'Test Vault Secrets retrieval' button because it would pass in an empty string for the `prefixPath` and `namespace` if they were not set.
This problem does not affect use of secrets in jobs, it is only encountered when trying to check settings while adding/updating credentials.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

