### PR TITLE
Raise exception when access is denied instead of silently failing

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -227,8 +227,8 @@ public class VaultAccessor implements Serializable {
         }
         int status = restResponse.getStatus();
         if (status == 403) {
-            logger.printf("Access denied to Vault Secrets at '%s'%n", path);
-            return true;
+            throw new VaultPluginException(
+                String.format("Access denied to Vault path '%s'", path));
         } else if (status == 404) {
             if (configuration.getFailIfNotFound()) {
                 throw new VaultPluginException(


### PR DESCRIPTION
This fixes #163 in the way asked for by @jetersen, but also adds a unit test to ensure correct behavior. I chose not to base it on the failIfNotFound flag since access denied shows a configuration issue that should be addressed immediately instead of "I have permissions, but it just doesn't exist" that failIfNotFound is for.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
