### PR TITLE
Fix token caching for multi-cluster multi-namespace environments

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -4,7 +4,11 @@ import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import java.io.Serializable;
 import java.util.Calendar;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -14,8 +18,97 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
     private final static Logger LOGGER = Logger
         .getLogger(AbstractVaultTokenCredentialWithExpiration.class.getName());
 
-    private Calendar tokenExpiry;
-    private String currentClientToken;
+    public static class CacheKey implements Serializable {
+        private final transient String vaultUrl;
+        private final transient String namespace;
+
+        public CacheKey(String vaultUrl, String namespace) {
+            this.vaultUrl = vaultUrl;
+            this.namespace = namespace;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("vaultUrl=%s, namespace=%s", vaultUrl, namespace);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CacheKey)) {
+                return false;
+            }
+            CacheKey cacheKey = (CacheKey) o;
+            return Objects.equals(vaultUrl, cacheKey.vaultUrl) && Objects.equals(
+                namespace, cacheKey.namespace);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(vaultUrl, namespace);
+        }
+    }
+
+    public static class TokenHolder implements Serializable {
+        private final transient CacheKey key;
+        private transient Calendar tokenExpiry;
+        private transient String token;
+
+        public TokenHolder(CacheKey key) {
+            this.key = key;
+        }
+
+        public synchronized Vault authorizeWithVault(
+            AbstractVaultTokenCredentialWithExpiration credentials, VaultConfig config) {
+            Vault vault = credentials.getVault(config);
+            if (tokenExpired()) {
+                token = credentials.getToken(vault);
+                config.token(token);
+                setTokenExpiry(vault);
+            } else {
+                config.token(token);
+            }
+            return vault;
+        }
+
+        private void setTokenExpiry(Vault vault) {
+            int tokenTTL = 0;
+            try {
+                tokenTTL = (int) vault.auth().lookupSelf().getTTL();
+            } catch (VaultException e) {
+                LOGGER.log(Level.WARNING, "Could not determine token expiration. " +
+                    "Check if token is allowed to access auth/token/lookup-self. " +
+                    "Assuming token TTL expired.", e);
+            }
+            tokenExpiry = Calendar.getInstance();
+            tokenExpiry.add(Calendar.SECOND, tokenTTL);
+        }
+
+        private boolean tokenExpired() {
+            if (tokenExpiry == null) {
+                return true;
+            }
+
+            boolean result = true;
+            Calendar now = Calendar.getInstance();
+            long timeDiffInMillis = now.getTimeInMillis() - tokenExpiry.getTimeInMillis();
+            if (timeDiffInMillis < -2000L) {
+                // token will be valid for at least another 2s
+                result = false;
+                LOGGER.log(Level.FINE, String.format("Auth token (for key %s) is still valid", key));
+            } else {
+                LOGGER.log(Level.FINE,
+                    String.format("Auth token (for key %s) has to be re-issued (%d)",
+                        key, timeDiffInMillis));
+            }
+
+            return result;
+        }
+    }
+
+    private final transient ConcurrentMap<CacheKey, TokenHolder> cache = new ConcurrentHashMap<>();
 
     protected AbstractVaultTokenCredentialWithExpiration(CredentialsScope scope, String id,
         String description) {
@@ -26,50 +119,13 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
 
     @Override
     public Vault authorizeWithVault(VaultConfig config) {
-        Vault vault = getVault(config);
-        if (tokenExpired()) {
-            currentClientToken = getToken(vault);
-            config.token(currentClientToken);
-            setTokenExpiry(vault);
-        } else {
-            config.token(currentClientToken);
-        }
-        return vault;
+        CacheKey key = new CacheKey(config.getAddress(), config.getNameSpace());
+        cache.putIfAbsent(key, new TokenHolder(key));
+        TokenHolder holder = cache.get(key);
+        return holder.authorizeWithVault(this, config);
     }
 
     protected Vault getVault(VaultConfig config) {
         return new Vault(config);
-    }
-
-    private void setTokenExpiry(Vault vault) {
-        int tokenTTL = 0;
-        try {
-            tokenTTL = (int) vault.auth().lookupSelf().getTTL();
-        } catch (VaultException e) {
-            LOGGER.log(Level.WARNING, "Could not determine token expiration. " +
-                "Check if token is allowed to access auth/token/lookup-self. " +
-                "Assuming token TTL expired.", e);
-        }
-        tokenExpiry = Calendar.getInstance();
-        tokenExpiry.add(Calendar.SECOND, tokenTTL);
-    }
-
-    private boolean tokenExpired() {
-        if (tokenExpiry == null) {
-            return true;
-        }
-
-        boolean result = true;
-        Calendar now = Calendar.getInstance();
-        long timeDiffInMillis = now.getTimeInMillis() - tokenExpiry.getTimeInMillis();
-        if (timeDiffInMillis < -2000L) {
-            // token will be valid for at least another 2s
-            result = false;
-            LOGGER.log(Level.FINE, "Auth token is still valid");
-        } else {
-            LOGGER.log(Level.FINE, "Auth token has to be re-issued" + timeDiffInMillis);
-        }
-
-        return result;
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -78,7 +78,8 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
             try {
                 tokenTTL = (int) vault.auth().lookupSelf().getTTL();
             } catch (VaultException e) {
-                LOGGER.log(Level.WARNING, "Could not determine token expiration. " +
+                LOGGER.log(Level.WARNING,
+                    String.format("Could not determine token expiration (for key %s). ", key) +
                     "Check if token is allowed to access auth/token/lookup-self. " +
                     "Assuming token TTL expired.", e);
             }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See https://github.com/jenkinsci/hashicorp-vault-plugin/issues/260.
New implementation uses caching criteria to differentiate tokens for different environments. So far I only came up with two possible attributes - server address and a namespace, but I have created `CacheKey` to allow for easy extension later on if more colliding attributes will be discovered. I have also added `transient` where I think it applies since I do not think we want to cache be ever written to the disk. I also added a little thread safety, although I am not sure if it is necessary (and I did not observe any issues with it so far) but it felt like it is.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
