### PR TITLE
Exclude credential ItemGroup context from serialization

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentials.java
@@ -23,7 +23,7 @@ public abstract class AbstractVaultBaseStandardCredentials extends BaseStandardC
     private String prefixPath;
     private String namespace;
     private Integer engineVersion;
-    private ItemGroup context;
+    private transient ItemGroup context;
 
     AbstractVaultBaseStandardCredentials(CredentialsScope scope, String id, String description) {
         super(scope, id, description);

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentialsTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/common/AbstractVaultBaseStandardCredentialsTest.java
@@ -1,0 +1,52 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.XmlFile;
+import hudson.model.ItemGroup;
+import java.io.File;
+import java.io.FileInputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.Issue;
+import org.w3c.dom.Document;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class AbstractVaultBaseStandardCredentialsTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Verify {@link AbstractVaultBaseStandardCredentials} does not attempt to serialize ItemGroup
+     * context.
+     */
+    @Test
+    @Issue("https://github.com/jenkinsci/hashicorp-vault-plugin/issues/264")
+    public void itemGroupContextNotSerialized() throws Exception {
+        ItemGroup ig = mock(ItemGroup.class);
+        VaultUsernamePasswordCredentialImpl cred = new VaultUsernamePasswordCredentialImpl(
+            CredentialsScope.GLOBAL, "foo", "foo credential");
+        cred.setContext(ig);
+
+        // serialize object using xstream
+        File out = folder.newFile();
+        new XmlFile(out).write(cred);
+
+        // verify document does not include include context field
+        try (FileInputStream fis = new FileInputStream(out)) {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(fis);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            String expression = "boolean(/com.datapipe.jenkins.vault.credentials.common.VaultUsernamePasswordCredentialImpl/context/node())";
+            assertEquals("false", xpath.compile(expression).evaluate(doc));
+        }
+    }
+}


### PR DESCRIPTION
Add `transient` modifier to `AbstractVaultBaseStandardCredentials#context` field. This excludes the ItemGroup context field from serialization when jenkins configuration is saved. This field is injected by VaultCredentialsProvider when credentials are resolved.

Fixes #264

<!-- Please describe your pull request here. -->

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
