### PR TITLE
Make sure token does not expire within 10 seconds instead of 2

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -62,8 +62,8 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         boolean result = true;
         Calendar now = Calendar.getInstance();
         long timeDiffInMillis = now.getTimeInMillis() - tokenExpiry.getTimeInMillis();
-        if (timeDiffInMillis < -2000L) {
-            // token will be valid for at least another 2s
+        if (timeDiffInMillis < -10000L) {
+            // token will be valid for at least another 10s
             result = false;
             LOGGER.log(Level.FINE, "Auth token is still valid");
         } else {


### PR DESCRIPTION
We have seen issues where a token is attempted to be used and is determined to be valid by the code, but expires before it is actually used. There is a buffer of 2 seconds set in the code, but this is apparently not long enough. Ideally this would be configurable, but for now I would like to extend that buffer to 10 seconds. Tokens will be considered expired if they expire within the next 10 seconds during the check instead of 2 seconds.

This is such a simple change that I decided not to create an issue for it, please let me know if you would like an issue instead.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] (see above) Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [x] (existing tests pass just fine, I'm not adding any features, just changing the window in which a token is considered expired) Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
