### PR TITLE
[JENKINS-71788] Fix timing of `SecretPatterns.getAggregateSecretPattern`

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/log/MaskingConsoleLogFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/log/MaskingConsoleLogFilter.java
@@ -30,20 +30,19 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
         updatePattern();
     }
 
-    private synchronized void updatePattern() {
+    private synchronized Pattern updatePattern() {
         if (!valuesToMask.equals(valuesToMaskInUse)) {
             List<String> values = valuesToMask.stream().filter(Objects::nonNull).collect(Collectors.toList());
             pattern = values.isEmpty() ? null : SecretPatterns.getAggregateSecretPattern(values);
             valuesToMaskInUse = new ArrayList<>(valuesToMask);
         }
+        return pattern;
     }
 
     @Override
     public OutputStream decorateLogger(Run run,
         final OutputStream logger) throws IOException, InterruptedException {
         return new SecretPatterns.MaskingOutputStream(logger,
-            () -> {
-                updatePattern();
                 // Only return a non-null pattern once there are secrets to mask. When a non-null
                 // pattern is returned it is cached and not supplied again. In cases like
                 // VaultBuildWrapper the secrets are added to the "valuesToMasker" list AFTER
@@ -51,8 +50,7 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
                 // the Pattern should only be returned once the secrets have been made available.
                 // Not to mention it is also a slight optimization when there is are no secrets
                 // to mask.
-                return pattern;
-            },
+                this::updatePattern,
             charsetName);
     }
 

--- a/src/main/java/com/datapipe/jenkins/vault/log/MaskingConsoleLogFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/log/MaskingConsoleLogFilter.java
@@ -5,8 +5,10 @@ import hudson.model.Run;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jenkinsci.plugins.credentialsbinding.masking.SecretPatterns;
 
@@ -18,12 +20,22 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
 
     private final String charsetName;
     private final List<String> valuesToMask;
-
+    private Pattern pattern;
+    private List<String> valuesToMaskInUse;
 
     public MaskingConsoleLogFilter(final String charsetName,
         List<String> valuesToMask) {
         this.charsetName = charsetName;
         this.valuesToMask = valuesToMask;
+        updatePattern();
+    }
+
+    private synchronized void updatePattern() {
+        if (!valuesToMask.equals(valuesToMaskInUse)) {
+            List<String> values = valuesToMask.stream().filter(Objects::nonNull).collect(Collectors.toList());
+            pattern = values.isEmpty() ? null : SecretPatterns.getAggregateSecretPattern(values);
+            valuesToMaskInUse = new ArrayList<>(valuesToMask);
+        }
     }
 
     @Override
@@ -31,6 +43,7 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
         final OutputStream logger) throws IOException, InterruptedException {
         return new SecretPatterns.MaskingOutputStream(logger,
             () -> {
+                updatePattern();
                 // Only return a non-null pattern once there are secrets to mask. When a non-null
                 // pattern is returned it is cached and not supplied again. In cases like
                 // VaultBuildWrapper the secrets are added to the "valuesToMasker" list AFTER
@@ -38,12 +51,7 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
                 // the Pattern should only be returned once the secrets have been made available.
                 // Not to mention it is also a slight optimization when there is are no secrets
                 // to mask.
-                List<String> values = valuesToMask.stream().filter(Objects::nonNull).collect(Collectors.toList());
-                if (!values.isEmpty()) {
-                    return SecretPatterns.getAggregateSecretPattern(values);
-                } else {
-                    return null;
-                }
+                return pattern;
             },
             charsetName);
     }


### PR DESCRIPTION
Fixes #311, supersedes #309, triggered by https://github.com/jenkinsci/credentials-binding-plugin/pull/260. Implementation is simpler than the `WeakHashMap` trick in https://github.com/jenkinsci/credentials-binding-plugin/pull/28. Not tested other than whatever CI covers.