### PR TITLE
Removed 1 unnecessary stubbing in AbstractAuthenticatingVaultTokenCre…

### DIFF
--- a/src/test/java/com/datapipe/jenkins/vault/credentials/SecondAbstractAuthenticatingVaultTokenCredentialTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/SecondAbstractAuthenticatingVaultTokenCredentialTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AbstractAuthenticatingVaultTokenCredentialTest {
+public class SecondAbstractAuthenticatingVaultTokenCredentialTest {
 
     private Vault vault;
     private Auth auth;
@@ -29,17 +29,23 @@ public class AbstractAuthenticatingVaultTokenCredentialTest {
         auth = mock(Auth.class);
         authResponse = mock(AuthResponse.class);
         when(vault.auth()).thenReturn(auth);
-        when(auth.withNameSpace(anyString())).thenReturn(auth);
         when(auth.loginByCert()).thenReturn(authResponse);
         when(authResponse.getAuthClientToken()).thenReturn("12345");
     }
 
     @Test
-    public void nonRootNamespace() {
+    public void rootNamespace() {
         ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
-        cred.setNamespace("foo");
+        cred.setNamespace("/");
         assertEquals("12345", cred.getToken(vault));
-        verify(auth).withNameSpace("foo");
+        verify(auth).withNameSpace(null);
+    }
+
+    @Test
+    public void nullNamespace() {
+        ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
+        assertEquals("12345", cred.getToken(vault));
+        verify(auth, never()).withNameSpace(any());
     }
 
     static class ExampleVaultTokenCredential extends AbstractAuthenticatingVaultTokenCredential {


### PR DESCRIPTION
…dentialTest.java

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
In our analysis of the project, we observed that 
1 unnecessary stubbing which stubbed `withNameSpace` method in `setUp` is created but is never executed by 2 tests `AbstractAuthenticatingVaultTokenCredentialTest.rootNamespace`, `AbstractAuthenticatingVaultTokenCredentialTest.nullNamespace`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.