### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultBindingStep.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultBindingStep.java
@@ -28,6 +28,7 @@ import com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter;
 import com.datapipe.jenkins.vault.model.VaultSecret;
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.console.ConsoleLogFilter;
@@ -43,7 +44,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback.TailCall;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
@@ -182,7 +182,7 @@ public class VaultBindingStep extends Step {
             return "withVault";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Vault Plugin";

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultCertificateCredentialsBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultCertificateCredentialsBinding.java
@@ -1,5 +1,6 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.FilePath;
@@ -13,7 +14,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.jenkinsci.plugins.credentialsbinding.impl.UnbindableDir;
@@ -46,7 +46,7 @@ public class VaultCertificateCredentialsBinding extends
     }
 
     @Override
-    public MultiEnvironment bind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher,
+    public MultiEnvironment bind(@NonNull Run<?, ?> build, FilePath workspace, Launcher launcher,
         TaskListener listener)
         throws IOException, InterruptedException {
         VaultCertificateCredentials credentials = this.getCredentials(build);

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialBinding.java
@@ -1,13 +1,13 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.credentialsbinding.Binding;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
@@ -25,10 +25,10 @@ public class VaultStringCredentialBinding extends Binding<VaultStringCredential>
         return VaultStringCredential.class;
     }
 
-    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build,
+    @Override public SingleEnvironment bindSingle(@NonNull Run<?,?> build,
                                                   @Nullable FilePath workspace,
                                                   @Nullable Launcher launcher,
-                                                  @Nonnull TaskListener listener) throws IOException, InterruptedException {
+                                                  @NonNull TaskListener listener) throws IOException, InterruptedException {
         return new SingleEnvironment(getCredentials(build).getSecret().getPlainText());
     }
 

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialBinding.java
@@ -1,5 +1,6 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
 import hudson.FilePath;
@@ -13,7 +14,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.kohsuke.stapler.AncestorInPath;
@@ -45,7 +45,7 @@ public class VaultUsernamePasswordCredentialBinding extends
     }
 
     @Override
-    public MultiEnvironment bind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher,
+    public MultiEnvironment bind(@NonNull Run<?, ?> build, FilePath workspace, Launcher launcher,
         TaskListener listener)
         throws IOException, InterruptedException {
         VaultUsernamePasswordCredential credentials = this.getCredentials(build);

--- a/src/test/java/com/datapipe/jenkins/vault/VaultBindingStepWithMockAccessor.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultBindingStepWithMockAccessor.java
@@ -6,6 +6,7 @@ import com.bettercloud.vault.rest.RestResponse;
 import com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential;
 import com.datapipe.jenkins.vault.credentials.VaultCredential;
 import com.datapipe.jenkins.vault.model.VaultSecret;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Run;
@@ -17,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -103,7 +103,7 @@ public class VaultBindingStepWithMockAccessor extends VaultBindingStep {
             return "withVaultMock";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Vault Mock Plugin";


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
