### PR TITLE
JENKINS-73398: Support credential snapshots

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultSSHUserPrivateKeyImpl.java
@@ -1,6 +1,7 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsSnapshotTaker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
@@ -152,6 +153,50 @@ public class VaultSSHUserPrivateKeyImpl extends AbstractVaultBaseStandardCredent
         @SuppressWarnings("unused") // used by stapler
         public ListBoxModel doFillEngineVersionItems(@AncestorInPath Item context) {
             return engineVersions(context);
+        }
+    }
+
+    static class SelfContained extends VaultSSHUserPrivateKeyImpl {
+        private final String username;
+        private final String privateKey;
+        private final Secret passphrase;
+
+        public SelfContained(VaultSSHUserPrivateKeyImpl base) {
+            super(base.getScope(), base.getId(), base.getDescription());
+            username = base.getUsername();
+            privateKey = base.getPrivateKey();
+            passphrase = base.getPassphrase();
+        }
+
+        @NonNull
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @NonNull
+        @Override
+        public String getPrivateKey() {
+            return privateKey;
+        }
+
+        @NonNull
+        @Override
+        public Secret getPassphrase() {
+            return passphrase;
+        }
+    }
+
+    @Extension
+    public static class SnapshotTaker extends CredentialsSnapshotTaker<VaultSSHUserPrivateKeyImpl> {
+        @Override
+        public Class<VaultSSHUserPrivateKeyImpl> type() {
+            return VaultSSHUserPrivateKeyImpl.class;
+        }
+
+        @Override
+        public VaultSSHUserPrivateKeyImpl snapshot(VaultSSHUserPrivateKeyImpl credentials) {
+            return new SelfContained(credentials);
         }
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStringCredentialImpl.java
@@ -1,6 +1,7 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsSnapshotTaker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
@@ -82,5 +83,33 @@ public class VaultStringCredentialImpl extends AbstractVaultBaseStandardCredenti
             return engineVersions(context);
         }
 
+    }
+
+    static class SelfContained extends VaultStringCredentialImpl {
+        private final Secret secret;
+
+        public SelfContained(VaultStringCredentialImpl base) {
+            super(base.getScope(), base.getId(), base.getDescription());
+            secret = base.getSecret();
+        }
+
+        @NonNull
+        @Override
+        public Secret getSecret() {
+            return secret;
+        }
+    }
+
+    @Extension
+    public static class SnapshotTaker extends CredentialsSnapshotTaker<VaultStringCredentialImpl> {
+        @Override
+        public Class<VaultStringCredentialImpl> type() {
+            return VaultStringCredentialImpl.class;
+        }
+
+        @Override
+        public VaultStringCredentialImpl snapshot(VaultStringCredentialImpl credentials) {
+            return new SelfContained(credentials);
+        }
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultUsernamePasswordCredentialImpl.java
@@ -1,6 +1,7 @@
 package com.datapipe.jenkins.vault.credentials.common;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsSnapshotTaker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Item;
@@ -110,6 +111,42 @@ public class VaultUsernamePasswordCredentialImpl extends AbstractVaultBaseStanda
         @SuppressWarnings("unused") // used by stapler
         public ListBoxModel doFillEngineVersionItems(@AncestorInPath Item context) {
             return engineVersions(context);
+        }
+    }
+
+    static class SelfContained extends VaultUsernamePasswordCredentialImpl {
+        private final String username;
+        private final Secret password;
+
+        public SelfContained(VaultUsernamePasswordCredentialImpl base) {
+            super(base.getScope(), base.getId(), base.getDescription());
+            username = base.getUsername();
+            password = base.getPassword();
+        }
+
+        @NonNull
+        @Override
+        public String getUsername() {
+            return username;
+        }
+
+        @NonNull
+        @Override
+        public Secret getPassword() {
+            return password;
+        }
+    }
+
+    @Extension
+    public static class SnapshotTaker extends CredentialsSnapshotTaker<VaultUsernamePasswordCredentialImpl> {
+        @Override
+        public Class<VaultUsernamePasswordCredentialImpl> type() {
+            return VaultUsernamePasswordCredentialImpl.class;
+        }
+
+        @Override
+        public VaultUsernamePasswordCredentialImpl snapshot(VaultUsernamePasswordCredentialImpl credentials) {
+            return new SelfContained(credentials);
         }
     }
 }


### PR DESCRIPTION
Support taking snapshots of Vault secrets to allow them to be used properly on agents.

<!-- Please describe your pull request here. -->

### Testing done

Have run this locally in combination with jenkinsci/artifactory-artifact-manager-plugin#53 and it works a charm.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
