### PR TITLE
Rename tokenExpiry field to prevent Folders corruption issues when upgrading from old versions of this plugin

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -44,14 +44,14 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         this.usePolicies = usePolicies;
     }
 
-    // Renamed to prevent XStream from attempting to deserialize old instances of this class which had the type `Calendar` prior to https://github.com/jenkinsci/hashicorp-vault-plugin/pull/223.
-    private transient Map<String, Calendar> tokenExpiry2;
+    // Renamed from tokenExpiry to prevent XStream from attempting to deserialize old instances of this class which had the type `Calendar` prior to https://github.com/jenkinsci/hashicorp-vault-plugin/pull/223.
+    private transient Map<String, Calendar> tokenExpiryCache;
     private transient Map<String, String> tokenCache;
 
     protected AbstractVaultTokenCredentialWithExpiration(CredentialsScope scope, String id,
         String description) {
         super(scope, id, description);
-        tokenExpiry2 = new HashMap<>();
+        tokenExpiryCache = new HashMap<>();
         tokenCache = new HashMap<>();
     }
 
@@ -109,7 +109,7 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         // Upgraded instances can have these not initialized in the constructor (serialized jobs possibly)
         if (tokenCache == null) {
             tokenCache = new HashMap<>();
-            tokenExpiry2 = new HashMap<>();
+            tokenExpiryCache = new HashMap<>();
         }
 
         String cacheKey = getCacheKey(policies);
@@ -151,11 +151,11 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         }
         Calendar expiry = Calendar.getInstance();
         expiry.add(Calendar.SECOND, tokenTTL);
-        tokenExpiry2.put(cacheKey, expiry);
+        tokenExpiryCache.put(cacheKey, expiry);
     }
 
     private boolean tokenExpired(String cacheKey) {
-        Calendar expiry = tokenExpiry2.get(cacheKey);
+        Calendar expiry = tokenExpiryCache.get(cacheKey);
         if (expiry == null) {
             return true;
         }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -44,13 +44,14 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         this.usePolicies = usePolicies;
     }
 
-    private transient Map<String, Calendar> tokenExpiry;
+    // Renamed to prevent XStream from attempting to deserialize old instances of this class which had the type `Calendar` prior to https://github.com/jenkinsci/hashicorp-vault-plugin/pull/223.
+    private transient Map<String, Calendar> tokenExpiry2;
     private transient Map<String, String> tokenCache;
 
     protected AbstractVaultTokenCredentialWithExpiration(CredentialsScope scope, String id,
         String description) {
         super(scope, id, description);
-        tokenExpiry = new HashMap<>();
+        tokenExpiry2 = new HashMap<>();
         tokenCache = new HashMap<>();
     }
 
@@ -108,7 +109,7 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         // Upgraded instances can have these not initialized in the constructor (serialized jobs possibly)
         if (tokenCache == null) {
             tokenCache = new HashMap<>();
-            tokenExpiry = new HashMap<>();
+            tokenExpiry2 = new HashMap<>();
         }
 
         String cacheKey = getCacheKey(policies);
@@ -150,11 +151,11 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
         }
         Calendar expiry = Calendar.getInstance();
         expiry.add(Calendar.SECOND, tokenTTL);
-        tokenExpiry.put(cacheKey, expiry);
+        tokenExpiry2.put(cacheKey, expiry);
     }
 
     private boolean tokenExpired(String cacheKey) {
-        Calendar expiry = tokenExpiry.get(cacheKey);
+        Calendar expiry = tokenExpiry2.get(cacheKey);
         if (expiry == null) {
             return true;
         }


### PR DESCRIPTION
XStream attempts to deserialize all fields in XML files that have a corresponding field in the class, even if it is marked `transient`. This means that #325 did not actually fix the issues described in #323, #324, and #326, which were caused by #223.

This should fix #323, #324, and #326. I tested it manually with a corrupted folder.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
