### PR TITLE
Make sure both tokenCache and tokenExpiryCache are initialized if needed

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java
@@ -107,7 +107,7 @@ public abstract class AbstractVaultTokenCredentialWithExpiration
     @Override
     public Vault authorizeWithVault(VaultConfig config, List<String> policies) {
         // Upgraded instances can have these not initialized in the constructor (serialized jobs possibly)
-        if (tokenCache == null) {
+        if (tokenCache == null || tokenExpiryCache == null) {
             tokenCache = new HashMap<>();
             tokenExpiryCache = new HashMap<>();
         }


### PR DESCRIPTION
It is possible for users who have a `AbstractVaultTokenCredentialWithExpiration` that was created after https://github.com/jenkinsci/hashicorp-vault-plugin/pull/223 and has not been resaved since https://github.com/jenkinsci/hashicorp-vault-plugin/pull/325 to still have a non-null `tokenCache` field on disk (and a non-null `tokenExpiry` field).

As of #336, this causes problems, because the following logic only checks for a non-null `tokenCache` to decide if the transient fields need to be initialized:

https://github.com/jenkinsci/hashicorp-vault-plugin/blob/946b53544a30ed5a2333e2a1abc79b1090d9be45/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpiration.java#L110

We need to adjust this logic to check for both `tokenCache` and the newly-renamed `tokenExpiryCache` to avoid issues for users who have gone through this upgrade path.

Fixes #340.

### Testing done

Untested.

The regression should be able to be reproduced in a `JenkinsRule` test if desired, but I do not see any existing `JenkinsRule` tests for the credentials types that are subclasses of `AbstractVaultTokenCredentialWithExpiration`, so it might take some effort.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
