### PR TITLE
possibility to use token role when creating child token

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -209,6 +209,7 @@ public class VaultAccessor implements Serializable {
         vaultAccessor.setConfig(vaultConfig);
         vaultAccessor.setCredential(credential);
         vaultAccessor.setPolicies(generatePolicies(config.getPolicies(), envVars));
+        vaultAccessor.setRole(config.getRole());
         vaultAccessor.setMaxRetries(config.getMaxRetries());
         vaultAccessor.setRetryIntervalMilliseconds(config.getRetryIntervalMilliseconds());
         vaultAccessor.init();

--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -47,6 +47,7 @@ public class VaultAccessor implements Serializable {
     private VaultConfig config;
     private VaultCredential credential;
     private List<String> policies;
+    private String role;
     private int maxRetries = 0;
     private int retryIntervalMilliseconds = 1000;
 
@@ -68,7 +69,7 @@ public class VaultAccessor implements Serializable {
             if (credential == null) {
                 vault = Vault.create(config);
             } else {
-                vault = credential.authorizeWithVault(config, policies);
+                vault = credential.authorizeWithVault(config, policies, role);
             }
 
             vault.withRetries(maxRetries, retryIntervalMilliseconds);
@@ -100,6 +101,14 @@ public class VaultAccessor implements Serializable {
 
     public void setPolicies(List<String> policies) {
         this.policies = policies;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
     }
 
     public int getMaxRetries() {

--- a/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
+++ b/src/main/java/com/datapipe/jenkins/vault/configuration/VaultConfiguration.java
@@ -52,6 +52,8 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
 
     private String policies;
 
+    private String role;
+
     private Boolean disableChildPoliciesOverride;
 
     private Integer timeout = DEFAULT_TIMEOUT;
@@ -78,6 +80,7 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         this.vaultNamespace = toCopy.vaultNamespace;
         this.prefixPath = toCopy.prefixPath;
         this.policies = toCopy.policies;
+        this.role = toCopy.role;
         this.disableChildPoliciesOverride = toCopy.disableChildPoliciesOverride;
         this.timeout = toCopy.timeout;
     }
@@ -108,6 +111,9 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         if (StringUtils.isBlank(result.getPolicies()) ||
                 (parent.getDisableChildPoliciesOverride() != null && parent.getDisableChildPoliciesOverride())) {
             result.setPolicies(parent.getPolicies());
+        }
+        if (result.role == null) {
+            result.setRole(parent.getRole());
         }
         if (result.timeout == null) {
             result.setTimeout(parent.getTimeout());
@@ -197,9 +203,18 @@ public class VaultConfiguration extends AbstractDescribableImpl<VaultConfigurati
         return policies;
     }
 
+    public String getRole() {
+        return role;
+    }
+
     @DataBoundSetter
     public void setPolicies(String policies) {
         this.policies = fixEmptyAndTrim(policies);
+    }
+
+    @DataBoundSetter
+    public void setRole(String role) {
+        this.role = fixEmptyAndTrim(role);
     }
 
     public Boolean getDisableChildPoliciesOverride() {

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredential.java
@@ -16,7 +16,7 @@ public abstract class AbstractVaultTokenCredential
     protected abstract String getToken(Vault vault);
 
     @Override
-    public Vault authorizeWithVault(VaultConfig config, List<String> policies) {
+    public Vault authorizeWithVault(VaultConfig config, List<String> policies, String role) {
         Vault vault = Vault.create(config);
         return Vault.create(config.token(getToken(vault)));
     }

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredential.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NameWith(VaultCredential.NameProvider.class)
 public interface VaultCredential extends StandardCredentials, Serializable {
 
-    Vault authorizeWithVault(VaultConfig config, List<String> policies);
+    Vault authorizeWithVault(VaultConfig config, List<String> policies, String role);
 
     class NameProvider extends CredentialsNameProvider<VaultCredential> {
 

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/config.jelly
@@ -17,6 +17,9 @@
     <f:entry field="engineVersion" title="K/V Engine Version">
       <f:select/>
     </f:entry>
+    <f:entry title="(Optional) Token Role" field="role">
+      <f:textbox/>
+    </f:entry>
     <f:entry title="(Optional) Job Policies" field="policies">
       <f:textarea/>
     </f:entry>

--- a/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-role.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/configuration/VaultConfiguration/help-role.html
@@ -1,0 +1,9 @@
+<div>
+  Specify token <strong>role</strong> name to use when creating new tokens (see <a href="https://developer.hashicorp.com/vault/api-docs/auth/token#create-update-token-role">Create / update token role</a>).
+  Roles enforce specific behavior when creating tokens that allow token functionality
+  that is otherwise not available or would require <strong>sudo/root</strong> privileges to access.
+  Role parameters, when set, override any provided options to the create endpoints.
+  The role name is also included in the token path, allowing all tokens created against a role
+  to be revoked using the <strong>/sys/leases/revoke-prefix</strong> endpoint.
+  Token roles are different from AppRole roles and also need to exist in order to use them.
+</div>

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/AbstractVaultTokenCredentialWithExpirationTest.java
@@ -56,7 +56,7 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(5L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
 
         verify(vaultConfig).token("fakeToken");
     }
@@ -68,9 +68,9 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
         when(childAuthResponse.getAuthClientToken()).thenReturn("childToken1", "childToken2");
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
         verify(vaultConfig).token("fakeToken1");
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies, null);
         verify(vaultConfig).token("childToken1");
     }
 
@@ -79,7 +79,7 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken");
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(0L);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, new ArrayList<>());
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, new ArrayList<>(), null);
 
         verify(vaultConfig, times(1)).token(anyString());
         verify(vaultConfig).token("fakeToken");
@@ -94,7 +94,7 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         // First response is for parent, second is for child
         when(lookupResponse.getTTL()).thenReturn(30L, 0L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies, null);
 
         verify(vaultConfig, times(2)).token(anyString());
         verify(vaultConfig).token("fakeToken");
@@ -108,13 +108,13 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(30L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
         verify(vaultConfig, times(2)).token("fakeToken1");
 
         // Different policies results in a new token
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies, null);
         verify(vaultConfig, times(2)).token("childToken1");
     }
 
@@ -125,15 +125,15 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(auth.lookupSelf()).thenReturn(lookupResponse);
         when(lookupResponse.getTTL()).thenReturn(0L);
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
         verify(vaultConfig, times(2)).token(anyString());
         verify(vaultConfig).token("fakeToken1");
         verify(vaultConfig).token("fakeToken2");
 
         // Different policies results in a new token
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, policies, null);
         verify(vaultConfig).token("childToken1");
         verify(vaultConfig).token("childToken2");
     }
@@ -143,8 +143,8 @@ public class AbstractVaultTokenCredentialWithExpirationTest {
         when(authResponse.getAuthClientToken()).thenReturn("fakeToken1", "fakeToken2");
         when(auth.lookupSelf()).thenThrow(new VaultException("Fail for testing"));
 
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
-        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
+        vaultTokenCredentialWithExpiration.authorizeWithVault(vaultConfig, null, null);
 
         verify(vaultConfig, times(2)).token(anyString());
         verify(vaultConfig).token("fakeToken1");

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
@@ -483,7 +483,7 @@ public class VaultConfigurationIT {
         when(cred.getDescription()).thenReturn("description");
         when(cred.getRoleId()).thenReturn("role-id-" + credentialId);
         when(cred.getSecretId()).thenReturn(Secret.fromString("secret-id-" + credentialId));
-        when(cred.authorizeWithVault(any(), eq(null))).thenReturn(vault);
+        when(cred.authorizeWithVault(any(), eq(null), eq(null))).thenReturn(vault);
         return cred;
 
     }


### PR DESCRIPTION
This PR allows you to - optionally - use a predefined [token role](https://developer.hashicorp.com/vault/api-docs/auth/token#create-update-token-role) when requesting new **child tokens** while `limiting policies`.

Instead of requiring the **requesting** AppRole to have to include all possible `token_policies` (and then just using a subset), the requesting AppRole can just be granted a single policy again granting to create a `token` using a predefined `token role` (which can request other `policies` **NOT** already included within the `token_policies`)

### Testing done

Sorry, I still need to try to write tests. I am not really a Java developer (getting it all running - and debugging - was already quite a pain for me. I will try to add those.

But what I did:

- setup a vault dev mode (with rudiment script)
```
#!/usr/bin/env bash

vault server -dev -dev-root-token-id=dev-only-token &
echo $! > .vault.pid

export VAULT_TOKEN=dev-only-token
export VAULT_ADDR=http://localhost:8200

# enable approle auth method
vault auth enable approle

# enable dummy-secrets
vault secrets enable -path=dummy-secrets -version=2 kv

# create jenkins approle
vault write auth/approle/role/jenkins \
  token_type=service \
  secret_id_ttl=43200m \
  token_ttl=10m \
  explicit_max_ttl=30m \
  secret_id_num_uses=0 \
  token_policies="jenkins_main"

# create token role
vault write auth/token/roles/jenkins token_type=batch allowed_policies="dummy1,dummy2" orphan=true renewable=false disallowed_policies="root,namespace-admin"

# get the role-id and echo that
echo "The role-id for 'jenkins' is: $(vault read -format=json auth/approle/role/jenkins/role-id | jq -r '.data.role_id') ..."

echo "The secret-id for 'jenkins' is: $(vault write -f -format=json auth/approle/role/jenkins/secret-id | jq -r '.data.secret_id') ..."

# policies

vault policy write dummy1 - <<EOF
path "dummy-secrets/data/*" {
  capabilities = ["read"]
}

path "dummy-secrets/metadata/*" {
  capabilities = ["read"]
}
EOF

vault policy write dummy2 - <<EOF
path "dummy-secrets/data/*" {
  capabilities = ["create", "update", "patch", "delete"]
}

path "dummy-secrets/metadata/*" {
  capabilities = ["create", "update", "patch", "delete"]
}
EOF

vault policy write jenkins_main - <<EOF
path "/auth/token/create/jenkins" {
  capabilities = ["create", "update"]
}
EOF

# create dummy secret dummy1 (in dummy-secrets)
vault kv put -mount=dummy-secrets dummy1 username=foo password=bar

echo "Done."
```

So the AppRole `jenkins` is created with only policy `jenkins_main` assigned via `token_policies`. `jenkins_main` itself allows to create child tokens using the `jenkins` **token role**. When trying to create child tokens, only `dummy1` or `dummy2` maybe be used (possibility to use globbing). So in this example, `dummy1` can read the secret at `dummy-secrets/data/dummy1`

Configure *global Vault* plugin by just providing the `url`, the AppRole and the **path prefix** `dummy-secrets`.

With that, using the slightly adjusted example from the README in a pipeline
```
node {
    // define the secrets and the env variables
    // engine version can be defined on secret, job, folder or global.
    // the default is engine version 2 unless otherwise specified globally.
    def secrets = [
        [path: 'dummy1', secretValues: [
            [envVar: 'username', vaultKey: 'username'],
            [envVar: 'password', vaultKey: 'password']
            ]
        ]
    ]

    // optional configuration, if you do not provide this the next higher configuration
    // (e.g. folder or global) will be used
    def configuration = [policies: "dummy1", role: "jenkins"]

    // inside this block your credentials will be available as env variables
    withVault([configuration: configuration, vaultSecrets: secrets]) {
        sh 'echo Username: $username'
        sh 'echo Password: $password'
    }
}
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


