### PR TITLE
Normalize path when using kv v1

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -25,7 +25,6 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
 import io.github.jopenlibs.vault.response.VaultResponse;
 import io.github.jopenlibs.vault.rest.RestResponse;
 import java.io.PrintStream;
-import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -41,7 +40,6 @@ import org.apache.commons.text.StringSubstitutor;
 
 public class VaultAccessor implements Serializable {
 
-    @Serial
     private static final long serialVersionUID = 1L;
 
     private VaultConfig config;
@@ -126,11 +124,13 @@ public class VaultAccessor implements Serializable {
 
     public LogicalResponse read(String path, Integer engineVersion) {
         try {
+            String normalizedPath = normalizePath(path);
             this.config.engineVersion(engineVersion);
-            return vault.logical().read(path);
+            return vault.logical().read(normalizedPath);
         } catch (VaultException e) {
             throw new VaultPluginException(
-                "could not read from vault: " + e.getMessage() + " at path: " + path, e);
+                "could not read from vault: " + e.getMessage() + " at path: "
+                    + normalizePath(path), e);
         }
     }
 
@@ -315,5 +315,19 @@ public class VaultAccessor implements Serializable {
         configuration.fixDefaults();
 
         return configuration;
+    }
+
+    /**
+     * Normalize user-supplied Vault paths so we don't send leading or duplicate slashes to Vault.
+     * Leading slashes cause requests like "/v1//path" which Vault replies to with HTTP 301 for KV v1.
+     */
+    static String normalizePath(String path) {
+        if (StringUtils.isBlank(path)) {
+            return path;
+        }
+        // remove any leading slashes
+        String cleaned = path.replaceFirst("^/+", "");
+        // collapse duplicate separators inside the path
+        return cleaned.replaceAll("/{2,}", "/");
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -25,6 +25,7 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
 import io.github.jopenlibs.vault.response.VaultResponse;
 import io.github.jopenlibs.vault.rest.RestResponse;
 import java.io.PrintStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -39,6 +40,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 
 public class VaultAccessor implements Serializable {
+
+    @Serial
 
     private static final long serialVersionUID = 1L;
 
@@ -328,7 +331,7 @@ public class VaultAccessor implements Serializable {
 
         // remove any leading slashes
         String cleaned = StringUtils.stripStart(path, "/");
-        
+
         // fast-path: nothing to do in the common case
         if (!cleaned.contains("//")) {
             return cleaned;

--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -325,9 +325,16 @@ public class VaultAccessor implements Serializable {
         if (StringUtils.isBlank(path)) {
             return path;
         }
+
         // remove any leading slashes
-        String cleaned = path.replaceFirst("^/+", "");
-        // collapse duplicate separators inside the path
+        String cleaned = StringUtils.stripStart(path, "/");
+        
+        // fast-path: nothing to do in the common case
+        if (!cleaned.contains("//")) {
+            return cleaned;
+        }
+
+        // collapse duplicate separators
         return cleaned.replaceAll("/{2,}", "/");
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -42,7 +42,6 @@ import org.apache.commons.text.StringSubstitutor;
 public class VaultAccessor implements Serializable {
 
     @Serial
-
     private static final long serialVersionUID = 1L;
 
     private VaultConfig config;
@@ -126,14 +125,14 @@ public class VaultAccessor implements Serializable {
     }
 
     public LogicalResponse read(String path, Integer engineVersion) {
+        String normalizedPath = normalizePath(path);
         try {
-            String normalizedPath = normalizePath(path);
             this.config.engineVersion(engineVersion);
             return vault.logical().read(normalizedPath);
         } catch (VaultException e) {
             throw new VaultPluginException(
                 "could not read from vault: " + e.getMessage() + " at path: "
-                    + normalizePath(path), e);
+                    + normalizedPath, e);
         }
     }
 

--- a/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
@@ -1,19 +1,55 @@
 package com.datapipe.jenkins.vault;
 
 import hudson.EnvVars;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.api.Logical;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class VaultAccessorTest {
 
     private static final String POLICIES_STR =
         "\npol1\n\nbase_${job_base_name}\njob/${job_name}\n job_${job_name_us}\nfolder/${job_folder}\nfolder_${job_folder_us}\nnode_${node_name}\n";
+
+    @Mock private Vault mockVault;
+    @Mock private Logical mockLogical;
+    @Mock private LogicalResponse mockResponse;
+
+    @Test
+    public void normalizePathStripsLeadingAndDuplicateSlashes() {
+        assertEquals("github/token/foo", VaultAccessor.normalizePath("/github//token/foo"));
+        assertEquals("prefix/bar/baz", VaultAccessor.normalizePath("///prefix//bar//baz"));
+    }
+
+    @Test
+    public void readUsesNormalizedPath() throws Exception {
+        VaultAccessor accessor = new VaultAccessor();
+
+        when(mockVault.logical()).thenReturn(mockLogical);
+        when(mockLogical.read("github/token/foo")).thenReturn(mockResponse);
+
+        Field vaultField = VaultAccessor.class.getDeclaredField("vault");
+        vaultField.setAccessible(true);
+        vaultField.set(accessor, mockVault);
+
+        accessor.read("/github//token/foo", 1);
+
+        verify(mockLogical).read("github/token/foo");
+    }
 
     @Test
     public void testGeneratePolicies() {

--- a/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
@@ -1,54 +1,25 @@
 package com.datapipe.jenkins.vault;
 
 import hudson.EnvVars;
-import io.github.jopenlibs.vault.Vault;
-import io.github.jopenlibs.vault.api.Logical;
-import io.github.jopenlibs.vault.response.LogicalResponse;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class VaultAccessorTest {
 
     private static final String POLICIES_STR =
         "\npol1\n\nbase_${job_base_name}\njob/${job_name}\n job_${job_name_us}\nfolder/${job_folder}\nfolder_${job_folder_us}\nnode_${node_name}\n";
 
-    @Mock private Vault mockVault;
-    @Mock private Logical mockLogical;
-    @Mock private LogicalResponse mockResponse;
-
     @Test
     public void normalizePathStripsLeadingAndDuplicateSlashes() {
         assertEquals("github/token/foo", VaultAccessor.normalizePath("/github//token/foo"));
         assertEquals("prefix/bar/baz", VaultAccessor.normalizePath("///prefix//bar//baz"));
-    }
-
-    @Test
-    public void readUsesNormalizedPath() throws Exception {
-        VaultAccessor accessor = new VaultAccessor();
-
-        when(mockVault.logical()).thenReturn(mockLogical);
-        when(mockLogical.read("github/token/foo")).thenReturn(mockResponse);
-
-        Field vaultField = VaultAccessor.class.getDeclaredField("vault");
-        vaultField.setAccessible(true);
-        vaultField.set(accessor, mockVault);
-
-        accessor.read("/github//token/foo", 1);
-
-        verify(mockLogical).read("github/token/foo");
     }
 
     @Test


### PR DESCRIPTION
- It wasn't needed in the previous version of the plugin as the BetterCloud Driver that has now been replaced followed the redirects
- Normalize Vault paths before reads to avoid KV v1 301s when users supply leading/double slashes.
- Added test for the path normalization
- fixes #358


### Testing done

- Added normalizePath, read with normalized path test to VaultAccessorTest.java
- mvn -q -Dtest=VaultAccessorTest test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed