### PR TITLE
Fix CVE-2025-67642: Filter SYSTEM-scoped credentials from item contexts

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredentialsProvider.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultCredentialsProvider.java
@@ -6,6 +6,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
@@ -13,10 +14,12 @@ import com.datapipe.jenkins.vault.credentials.common.AbstractVaultBaseStandardCr
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.security.ACL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import jenkins.model.Jenkins;
 import org.springframework.security.core.Authentication;
 
@@ -64,23 +67,40 @@ public class VaultCredentialsProvider extends CredentialsProvider {
                 creds.addAll(folderCreds);
             }
 
-            // Only return System-scoped credentials when the context is the global Jenkins instance
-            // This prevents exposure of System-scoped credentials to item/folder contexts
-            if (itemGroup == null || itemGroup == Jenkins.get()) {
-                List<C> globalCreds = DomainCredentials.getCredentials(
-                    SystemCredentialsProvider.getInstance().getDomainCredentialsMap(),
-                    type,
-                    domainRequirements,
-                    matcher
-                );
-                if (type != VaultCredential.class) {
-                    for (C c : globalCreds) {
-                        ((AbstractVaultBaseStandardCredentials) c).setContext(Jenkins.get());
-                    }
+            // Only include SYSTEM-scoped credentials when context is Jenkins (global).
+            // This prevents exposure of SYSTEM-scoped credentials to item/folder contexts (CVE-2025-67642).
+            boolean includeSystemCredentials = itemGroup instanceof Jenkins;
+            List<C> globalCreds = DomainCredentials.getCredentials(
+                SystemCredentialsProvider.getInstance().getDomainCredentialsMap(),
+                type,
+                domainRequirements,
+                matcher
+            );
+
+            for (C c : globalCreds) {
+                if (!includeSystemCredentials && CredentialsScope.SYSTEM == c.getScope()) {
+                    continue;
                 }
-                creds.addAll(globalCreds);
+                if (type != VaultCredential.class) {
+                    ((AbstractVaultBaseStandardCredentials) c).setContext(Jenkins.get());
+                }
+                creds.add(c);
             }
         }
         return creds;
+    }
+
+    @Override
+    @NonNull
+    public <C extends Credentials> List<C> getCredentialsInItem(@NonNull Class<C> type,
+        @NonNull Item item,
+        @Nullable Authentication authentication,
+        @NonNull List<DomainRequirement> domainRequirements) {
+        // Scoping to Items is not supported so using null when parent is Jenkins
+        // to not expose SYSTEM credentials to Items (CVE-2025-67642).
+        Objects.requireNonNull(item);
+        ItemGroup<?> parent = item.getParent();
+        ItemGroup<?> context = (parent instanceof Jenkins) ? null : parent;
+        return getCredentialsInItemGroup(type, context, authentication, domainRequirements);
     }
 }

--- a/src/test/java/com/datapipe/jenkins/vault/it/TopLevelJobSecurityTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/TopLevelJobSecurityTest.java
@@ -1,0 +1,117 @@
+package com.datapipe.jenkins.vault.it;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.datapipe.jenkins.vault.credentials.VaultCredential;
+import com.datapipe.jenkins.vault.credentials.VaultTokenCredential;
+import hudson.model.FreeStyleProject;
+import hudson.security.ACL;
+import hudson.util.Secret;
+import java.util.Collections;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Test for CVE-2025-67642: Top-level jobs should not see system-scoped credentials.
+ */
+public class TopLevelJobSecurityTest {
+
+    private static final String SYSTEM_SCOPED_CREDENTIAL_ID = "system-scoped-credential";
+    private static final String GLOBAL_SCOPED_CREDENTIAL_ID = "global-scoped-credential";
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    private FreeStyleProject topLevelProject;
+
+    @Before
+    public void setupJenkins() throws Exception {
+        // Create System-scoped credential (should NOT be accessible from jobs)
+        VaultCredential systemScopedCredential = new VaultTokenCredential(
+            CredentialsScope.SYSTEM,
+            SYSTEM_SCOPED_CREDENTIAL_ID,
+            "System-scoped credential",
+            Secret.fromString("system-token")
+        );
+
+        // Create Global-scoped credential (SHOULD be accessible from jobs)
+        VaultCredential globalScopedCredential = new VaultTokenCredential(
+            CredentialsScope.GLOBAL,
+            GLOBAL_SCOPED_CREDENTIAL_ID,
+            "Global-scoped credential",
+            Secret.fromString("global-token")
+        );
+
+        SystemCredentialsProvider.getInstance().setDomainCredentialsMap(
+            Collections.singletonMap(Domain.global(),
+                java.util.Arrays.asList(systemScopedCredential, globalScopedCredential))
+        );
+
+        // Create a TOP-LEVEL job (NOT inside a folder)
+        topLevelProject = jenkins.createFreeStyleProject("top-level-project");
+    }
+
+    @Test
+    public void systemScopedCredentialShouldNotBeAccessibleFromTopLevelJob() {
+        // Verify the project parent is Jenkins.get() (not a folder)
+        assertThat("Top-level project parent should be Jenkins instance",
+            topLevelProject.getParent() == Jenkins.get(), is(true));
+
+        // Try to lookup credentials from top-level job context
+        List<VaultCredential> credentials = CredentialsProvider.lookupCredentialsInItem(
+            VaultCredential.class,
+            topLevelProject,
+            ACL.SYSTEM2,
+            Collections.emptyList()
+        );
+
+        // Count System-scoped credentials
+        long systemScopedCount = credentials.stream()
+            .filter(c -> CredentialsScope.SYSTEM.equals(c.getScope()))
+            .count();
+
+        // This should be 0, but the vulnerability makes it 1
+        System.out.println("System-scoped credentials found in top-level job context: " + systemScopedCount);
+        System.out.println("Credentials found: " + credentials);
+
+        assertThat("Top-level job should NOT have access to System-scoped credentials",
+            systemScopedCount, is(0L));
+    }
+
+    @Test
+    public void globalScopedCredentialShouldBeAccessibleFromTopLevelJob() {
+        // Verify the project parent is Jenkins.get() (not a folder)
+        assertThat("Top-level project parent should be Jenkins instance",
+            topLevelProject.getParent() == Jenkins.get(), is(true));
+
+        // Try to lookup credentials from top-level job context
+        List<VaultCredential> credentials = CredentialsProvider.lookupCredentialsInItem(
+            VaultCredential.class,
+            topLevelProject,
+            ACL.SYSTEM2,
+            Collections.emptyList()
+        );
+
+        // Find Global-scoped credential
+        VaultCredential found = credentials.stream()
+            .filter(c -> GLOBAL_SCOPED_CREDENTIAL_ID.equals(c.getId()))
+            .findFirst()
+            .orElse(null);
+
+        // Global-scoped credential SHOULD be accessible
+        assertThat("Global-scoped credential should be accessible from top-level job",
+            found, is(notNullValue()));
+        assertThat("Found credential should have correct ID",
+            found.getId(), is(GLOBAL_SCOPED_CREDENTIAL_ID));
+    }
+}


### PR DESCRIPTION
## Summary

- Override `getCredentialsInItem` to pass `null` context for top-level jobs (items whose parent is Jenkins)
- Filter SYSTEM-scoped credentials in `getCredentialsInItemGroup` when the context is not the Jenkins instance
- Add `TopLevelJobSecurityTest` to verify SYSTEM-scoped credentials are not accessible from top-level jobs

This follows the same pattern used in the Azure Key Vault plugin fix for the same vulnerability.

## Test plan

- [x] Existing `SystemScopedCredentialsSecurityIT` tests pass (6 tests)
- [x] New `TopLevelJobSecurityTest` passes (2 tests)