### PR TITLE
✨ Add Vault Username-Password credential with static username

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredential.java
@@ -1,0 +1,23 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+
+@NameWith(value = VaultStaticUsernamePasswordCredential.NameProvider.class, priority = 32)
+public interface VaultStaticUsernamePasswordCredential extends StandardUsernamePasswordCredentials {
+
+    String getDisplayName();
+
+    class NameProvider extends CredentialsNameProvider<VaultStaticUsernamePasswordCredential> {
+
+        @NonNull
+        @Override
+        public String getName(VaultStaticUsernamePasswordCredential c) {
+            String description = Util.fixEmpty(c.getDescription());
+            return c.getDisplayName() + (description == null ? "" : " (" + description + ")");
+        }
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialBinding.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialBinding.java
@@ -1,0 +1,93 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Item;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
+import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import static com.datapipe.jenkins.vault.configuration.VaultConfiguration.engineVersions;
+import static org.apache.commons.lang.StringUtils.defaultIfBlank;
+
+public class VaultStaticUsernamePasswordCredentialBinding extends
+    MultiBinding<VaultStaticUsernamePasswordCredential> {
+
+    public static final String DEFAULT_USERNAME_VARIABLE = "USERNAME";
+    public static final String DEFAULT_PASSWORD_VARIABLE = "PASSWORD";
+
+    private final String usernameVariable;
+    private final String passwordVariable;
+
+    @DataBoundConstructor
+    public VaultStaticUsernamePasswordCredentialBinding(@Nullable String usernameVariable,
+        @Nullable String passwordVariable,
+        String credentialsId) {
+        super(credentialsId);
+        this.usernameVariable = defaultIfBlank(usernameVariable, DEFAULT_USERNAME_VARIABLE);
+        this.passwordVariable = defaultIfBlank(passwordVariable, DEFAULT_PASSWORD_VARIABLE);
+    }
+
+    @Override
+    protected Class<VaultStaticUsernamePasswordCredential> type() {
+        return VaultStaticUsernamePasswordCredential.class;
+    }
+
+    @Override
+    public MultiEnvironment bind(@NonNull Run<?, ?> build, FilePath workspace, Launcher launcher,
+        TaskListener listener) throws IOException, InterruptedException {
+        VaultStaticUsernamePasswordCredential credentials = this.getCredentials(build);
+        Map<String, String> map = new HashMap<>();
+        map.put(this.usernameVariable, credentials.getUsername());
+        map.put(this.passwordVariable, credentials.getPassword().getPlainText());
+        return new MultiEnvironment(map);
+    }
+
+    public String getUsernameVariable() {
+        return usernameVariable;
+    }
+
+    public String getPasswordVariable() {
+        return passwordVariable;
+    }
+
+    @Override
+    public Set<String> variables() {
+        Set<String> variables = new HashSet<>();
+        variables.add(this.usernameVariable);
+        variables.add(this.passwordVariable);
+        return variables;
+    }
+
+    @Extension
+    public static class DescriptorImpl
+        extends BindingDescriptor<VaultStaticUsernamePasswordCredential> {
+
+        @Override
+        protected Class<VaultStaticUsernamePasswordCredential> type() {
+            return VaultStaticUsernamePasswordCredential.class;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Vault Username-Password Credentials (Static Username)";
+        }
+
+        @SuppressWarnings("unused") // used by stapler
+        public ListBoxModel doFillEngineVersionItems(@AncestorInPath Item context) {
+            return engineVersions(context);
+        }
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl.java
@@ -1,0 +1,139 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsSnapshotTaker;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import static com.datapipe.jenkins.vault.configuration.VaultConfiguration.engineVersions;
+import static com.datapipe.jenkins.vault.credentials.common.VaultHelper.getVaultSecretKey;
+import static org.apache.commons.lang.StringUtils.defaultIfBlank;
+
+@SuppressWarnings("ALL")
+public class VaultStaticUsernamePasswordCredentialImpl extends AbstractVaultBaseStandardCredentials
+    implements VaultStaticUsernamePasswordCredential {
+
+    public static final String DEFAULT_PASSWORD_KEY = "password";
+
+    private static final long serialVersionUID = 1L;
+
+    private String username;
+    private String passwordKey;
+
+    @DataBoundConstructor
+    public VaultStaticUsernamePasswordCredentialImpl(CredentialsScope scope, String id,
+        String description) {
+        super(scope, id, description);
+    }
+
+    @NonNull
+    public String getUsername() {
+        return username == null ? "" : username;
+    }
+
+    @DataBoundSetter
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @NonNull
+    public String getPasswordKey() {
+        return passwordKey;
+    }
+
+    @DataBoundSetter
+    public void setPasswordKey(String passwordKey) {
+        this.passwordKey = defaultIfBlank(passwordKey, DEFAULT_PASSWORD_KEY);
+    }
+
+    @NonNull
+    @Override
+    public Secret getPassword() {
+        String secretKey = defaultIfBlank(passwordKey, DEFAULT_PASSWORD_KEY);
+        String secret = getVaultSecretKeyValue(secretKey);
+        return Secret.fromString(secret);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Vault Username-Password Credential (Static Username)";
+        }
+
+        public FormValidation doTestConnection(
+            @AncestorInPath ItemGroup<Item> context,
+            @QueryParameter("path") String path,
+            @QueryParameter("passwordKey") String passwordKey,
+            @QueryParameter("prefixPath") String prefixPath,
+            @QueryParameter("namespace") String namespace,
+            @QueryParameter("engineVersion") Integer engineVersion) {
+
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+            try {
+                getVaultSecretKey(path, defaultIfBlank(passwordKey, DEFAULT_PASSWORD_KEY),
+                    prefixPath, namespace, engineVersion, context);
+            } catch (Exception e) {
+                return FormValidation.error("FAILED to retrieve password key: \n" + e);
+            }
+
+            return FormValidation.ok("Successfully retrieved the password from Vault");
+        }
+
+        @SuppressWarnings("unused") // used by stapler
+        public ListBoxModel doFillEngineVersionItems(@AncestorInPath Item context) {
+            return engineVersions(context);
+        }
+    }
+
+    static class SelfContained extends VaultStaticUsernamePasswordCredentialImpl {
+        private final String resolvedUsername;
+        private final Secret password;
+
+        public SelfContained(VaultStaticUsernamePasswordCredentialImpl base) {
+            super(base.getScope(), base.getId(), base.getDescription());
+            resolvedUsername = base.getUsername();
+            password = base.getPassword();
+        }
+
+        @NonNull
+        @Override
+        public String getUsername() {
+            return resolvedUsername;
+        }
+
+        @NonNull
+        @Override
+        public Secret getPassword() {
+            return password;
+        }
+    }
+
+    @Extension
+    public static class SnapshotTaker
+        extends CredentialsSnapshotTaker<VaultStaticUsernamePasswordCredentialImpl> {
+
+        @Override
+        public Class<VaultStaticUsernamePasswordCredentialImpl> type() {
+            return VaultStaticUsernamePasswordCredentialImpl.class;
+        }
+
+        @Override
+        public VaultStaticUsernamePasswordCredentialImpl snapshot(
+            VaultStaticUsernamePasswordCredentialImpl credentials) {
+            return new SelfContained(credentials);
+        }
+    }
+}

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialBinding/config-variables.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialBinding/config-variables.jelly
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials">
+  <f:entry title="${%Username Variable}" field="usernameVariable">
+    <f:textbox default="USERNAME"/>
+  </f:entry>
+  <f:entry title="${%Password Variable}" field="passwordVariable">
+      <f:textbox default="PASSWORD"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialBinding/help.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialBinding/help.html
@@ -1,0 +1,4 @@
+<div>
+    Username/Password Jenkins credential where the username is provided as plain text and the
+    password is backed by a HashiCorp Vault secret.
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/credentials.jelly
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/credentials.jelly
@@ -1,0 +1,29 @@
+<?jelly escape-by-default='true'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
+  <f:entry title="${%Namespace}" field="namespace">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Prefix Path}" field="prefixPath">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Path}" field="path">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Username}" field="username">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%Password Key}" field="passwordKey" default="password">
+    <f:textbox/>
+  </f:entry>
+  <f:entry name="engineVersion" title="${%K/V Engine Version}" field="engineVersion">
+      <f:select/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+
+  <l:isAdmin>
+    <f:validateButton title="${%Test Vault Secrets retrieval}" progress="${%Testing retrieval of password key...}"
+      method="testConnection" with="path,passwordKey,prefixPath,namespace,engineVersion" />
+  </l:isAdmin>
+
+</j:jelly>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-namespace.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-namespace.html
@@ -1,0 +1,8 @@
+<div>
+  The <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Namespace</a> the
+  secret resides in. Leave blank if namespaces are not enabled or the secret is part of the root
+  namespace.
+  <p>
+    <strong>Note:</strong> Namespaces are a feature of Vault Enterprise.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-path.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-path.html
@@ -1,0 +1,3 @@
+<div>
+  The Vault secret path. Example "<code>kv/eng/database/app1</code>".
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-prefixPath.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-prefixPath.html
@@ -1,0 +1,8 @@
+<div>
+  The secret engine prefix path. Use this to identify the path the secret engine (i.e. <code>kv</code>)
+  is mounted to if it is not mounted at the root.
+  <p>
+    For example if the secret path is "<code>team1/kv/database</code>" the prefix path would be "<code>team1/kv</code>".
+    If the secret path is "<code>kv/database</code>" the prefix path can be left blank.
+  </p>
+</div>

--- a/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-username.html
+++ b/src/main/resources/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImpl/help-username.html
@@ -1,0 +1,5 @@
+<div>
+  The plain-text username. Unlike the standard Vault Username-Password credential, this value is
+  stored directly in Jenkins and is <strong>not</strong> retrieved from Vault. Only the password
+  is fetched from Vault.
+</div>

--- a/src/test/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImplTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/common/VaultStaticUsernamePasswordCredentialImplTest.java
@@ -1,0 +1,100 @@
+package com.datapipe.jenkins.vault.credentials.common;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.XmlFile;
+import hudson.model.ItemGroup;
+import java.io.File;
+import java.io.FileInputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.w3c.dom.Document;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class VaultStaticUsernamePasswordCredentialImplTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * Verify that the transient {@code context} field is not serialized.
+     */
+    @Test
+    public void itemGroupContextNotSerialized() throws Exception {
+        ItemGroup ig = mock(ItemGroup.class);
+        VaultStaticUsernamePasswordCredentialImpl cred =
+            new VaultStaticUsernamePasswordCredentialImpl(
+                CredentialsScope.GLOBAL, "foo", "foo credential");
+        cred.setUsername("admin");
+        cred.setContext(ig);
+
+        File out = folder.newFile();
+        new XmlFile(out).write(cred);
+
+        try (FileInputStream fis = new FileInputStream(out)) {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(fis);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            String expression =
+                "boolean(/com.datapipe.jenkins.vault.credentials.common"
+                    + ".VaultStaticUsernamePasswordCredentialImpl/context/node())";
+            assertEquals("false", xpath.compile(expression).evaluate(doc));
+        }
+    }
+
+    /**
+     * Verify that the plain-text {@code username} field is serialized and restored correctly.
+     */
+    @Test
+    public void usernameSerialized() throws Exception {
+        VaultStaticUsernamePasswordCredentialImpl cred =
+            new VaultStaticUsernamePasswordCredentialImpl(
+                CredentialsScope.GLOBAL, "bar", "bar credential");
+        cred.setUsername("static-user");
+        cred.setPasswordKey("secret");
+
+        File out = folder.newFile();
+        new XmlFile(out).write(cred);
+
+        try (FileInputStream fis = new FileInputStream(out)) {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(fis);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+
+            String usernameExpression =
+                "string(/com.datapipe.jenkins.vault.credentials.common"
+                    + ".VaultStaticUsernamePasswordCredentialImpl/username)";
+            assertEquals("static-user", xpath.compile(usernameExpression).evaluate(doc));
+
+            String passwordKeyExpression =
+                "string(/com.datapipe.jenkins.vault.credentials.common"
+                    + ".VaultStaticUsernamePasswordCredentialImpl/passwordKey)";
+            assertEquals("secret", xpath.compile(passwordKeyExpression).evaluate(doc));
+        }
+    }
+
+    /**
+     * Verify default values: blank passwordKey defaults to "password", and username defaults to
+     * empty string when null.
+     */
+    @Test
+    public void defaultValues() {
+        VaultStaticUsernamePasswordCredentialImpl cred =
+            new VaultStaticUsernamePasswordCredentialImpl(
+                CredentialsScope.GLOBAL, "baz", "baz credential");
+
+        assertEquals("", cred.getUsername());
+
+        cred.setPasswordKey(null);
+        assertEquals(VaultStaticUsernamePasswordCredentialImpl.DEFAULT_PASSWORD_KEY,
+            cred.getPasswordKey());
+    }
+}

--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultStaticUsernamePasswordCredentialIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultStaticUsernamePasswordCredentialIT.java
@@ -1,0 +1,128 @@
+package com.datapipe.jenkins.vault.it;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.datapipe.jenkins.vault.credentials.common.VaultStaticUsernamePasswordCredential;
+import com.datapipe.jenkins.vault.credentials.common.VaultStaticUsernamePasswordCredentialImpl;
+import hudson.FilePath;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.getShellString;
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.getVariable;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+public class VaultStaticUsernamePasswordCredentialIT {
+
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Test
+    public void shouldRetrievePasswordFromVaultWithStaticUsername() {
+        final String credentialsId = "staticUsernameCredential";
+        final String username = "static-user";
+        final String password = "vaultPassword";
+        final String jobId = "testJob";
+        story.then(r -> {
+            VaultStaticUsernamePasswordCredential credential = mock(
+                VaultStaticUsernamePasswordCredentialImpl.class);
+            when(credential.forRun(any(Run.class))).thenReturn(credential);
+            when(credential.getId()).thenReturn(credentialsId);
+            when(credential.getUsername()).thenReturn(username);
+            when(credential.getPassword()).thenReturn(Secret.fromString(password));
+            CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                .addCredentials(Domain.global(), credential);
+            WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobId);
+            p.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + " withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '"
+                + credentialsId
+                + "', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) { "
+                + "      " + getShellString() + " 'echo " + getVariable("USERNAME") + ":" + getVariable("PASSWORD") + " > script'\n"
+                + "  }\n"
+                + "}", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(b));
+            story.j.assertLogNotContains(password, b);
+            FilePath script = story.j.jenkins.getWorkspaceFor(p).child("script");
+            assertEquals(username + ":" + password, script.readToString().trim());
+        });
+    }
+
+    @Test
+    public void shouldRetrievePasswordFromVaultWithCustomPasswordKey() {
+        final String credentialsId = "customKeyCredential";
+        final String username = "static-user";
+        final String password = "vaultPassword";
+        final String jobId = "testJob";
+        story.then(r -> {
+            VaultStaticUsernamePasswordCredentialImpl credential =
+                new VaultStaticUsernamePasswordCredentialImpl(null, credentialsId, "Test Credentials");
+            credential.setPath("secret/myapp");
+            credential.setUsername(username);
+            credential.setPasswordKey("secret");
+            credential.setEngineVersion(1);
+
+            VaultStaticUsernamePasswordCredentialImpl credentialSpy = spy(credential);
+            doReturn(credentialsId).when(credentialSpy).getId();
+            doReturn(username).when(credentialSpy).getUsername();
+            doReturn(Secret.fromString(password)).when(credentialSpy).getPassword();
+            CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                .addCredentials(Domain.global(), credentialSpy);
+            WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobId);
+            p.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + "withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '"
+                + credentialsId
+                + "', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {"
+                + "      " + getShellString() + " 'echo " + getVariable("USERNAME") + ":" + getVariable("PASSWORD") + " > script'\n"
+                + "  }\n"
+                + "}", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            story.j.assertBuildStatus(Result.SUCCESS, story.j.waitForCompletion(b));
+            story.j.assertLogNotContains(password, b);
+            FilePath script = story.j.jenkins.getWorkspaceFor(p).child("script");
+            assertEquals(username + ":" + password, script.readToString().trim());
+        });
+    }
+
+    @Test
+    public void shouldFailIfPasswordKeyMissingFromVault() {
+        final String credentialsId = "missingKeyCredential";
+        final String jobId = "testJob";
+        story.then(r -> {
+            VaultStaticUsernamePasswordCredentialImpl credential =
+                new VaultStaticUsernamePasswordCredentialImpl(null, credentialsId, "Test Credentials");
+            credential.setPath("secret/myapp");
+            credential.setUsername("static-user");
+            credential.setPasswordKey(null);
+            credential.setEngineVersion(1);
+            CredentialsProvider.lookupStores(story.j.jenkins).iterator().next()
+                .addCredentials(Domain.global(), credential);
+            WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, jobId);
+            p.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + " withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: '"
+                + credentialsId
+                + "', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) { "
+                + "      " + getShellString() + " 'echo " + getVariable("USERNAME") + ":" + getVariable("PASSWORD") + " > script'\n"
+                + "  }\n"
+                + "}", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b));
+            story.j.assertLogContains("credentials", b);
+        });
+    }
+}


### PR DESCRIPTION
[Linked issue](https://github.com/jenkinsci/hashicorp-vault-plugin/issues/362)

Introduce VaultStaticUsernamePasswordCredential, a new credential type where the username is stored as plain text in Jenkins while the password is retrieved from HashiCorp Vault.

This is useful when only the password is managed in Vault (e.g. a shared service account whose username is well-known and static), avoiding the need to store a redundant username secret in Vault.

New classes follow the same patterns as VaultUsernamePasswordCredential:
- VaultStaticUsernamePasswordCredential (interface + NameProvider)
- VaultStaticUsernamePasswordCredentialImpl (impl, descriptor, SelfContained snapshot, SnapshotTaker)
- VaultStaticUsernamePasswordCredentialBinding (MultiBinding exposing USERNAME and PASSWORD environment variables)

Jelly UI, field-level help HTML, integration tests, and unit tests (XML serialization, default values) are all included.

<!-- Please describe your pull request here. -->

### Testing done

mvn verify passing, including new tests from this PR.
Except tests from WindowsFilePermissionsTest that were skipped since I don't have a Windows machine available right now.
Also launched Jenkins locally.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
