### PR TITLE
Rely on jenkinsci organization release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,0 @@
-# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
-_extends: .github


### PR DESCRIPTION
## Rely on jenkinsci organization release drafter configuration

Release drafter v7 dropped support for `_extends: .github` in the configuration.  It either needs to be removed or replaced with a more complete specification like:

`_extends: github:jenkinsci/.github:/.github/release-drafter.yml`

This pull request removes it because the ["Enabling CD" instructions](https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter) say:

> You can delete any existing Release Drafter configuration ... as that will be subsumed by the CD workflow

Adapts to release drafter changes in pull request:

* https://github.com/release-drafter/release-drafter/pull/1475

Follows the pattern in credentials plugin pull request:

* https://github.com/jenkinsci/credentials-plugin/pull/1037

Automatic releases will fail until this is merged if the plugin is using the [1.8.2 release](https://github.com/jenkins-infra/github-reusable-workflows/releases/tag/v1.8.2) of reusable workflows.

### Testing done

* None.  Has worked well in many repositories, not expecting any issues in this repository

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
