### PR TITLE
Add vaultCredentials() step for Pipeline environment blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/com/datapipe/jenkins/vault/VaultCredentialsStep.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultCredentialsStep.java
@@ -1,0 +1,214 @@
+package com.datapipe.jenkins.vault;
+
+import com.datapipe.jenkins.vault.configuration.VaultConfiguration;
+import com.datapipe.jenkins.vault.credentials.VaultCredential;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import java.io.Serial;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Pipeline step that fetches a single value from a Vault KV secret and returns it as a String.
+ * Designed for use inside Declarative Pipeline {@code environment {}} blocks.
+ *
+ * <p>The first argument combines the KV path and field name: the last segment after the final
+ * {@code /} is used as the field key, and everything before it is the secret path.
+ *
+ * <pre>
+ * environment {
+ *     DB_HOST = vaultCredentials('secret/myapp/db/host', 'vault-approle')
+ *     DB_PASS = vaultCredentials('secret/myapp/db/password', 'vault-approle',
+ *                   vaultUrl: 'https://vault:8200', vaultNamespace: 'prod')
+ * }
+ * </pre>
+ *
+ * <p>When {@code maskSecret} is {@code true} (the default), the resolved value is registered with
+ * {@link VaultMaskedValuesFilter} so it is automatically redacted from subsequent console output.
+ */
+public class VaultCredentialsStep extends Step {
+
+    private final String pathAndKey;
+    private final String credentialsId;
+    private String vaultUrl;
+    private String vaultNamespace;
+    private boolean maskSecret = true;
+
+    @DataBoundConstructor
+    public VaultCredentialsStep(@NonNull String pathAndKey, @NonNull String credentialsId) {
+        this.pathAndKey = pathAndKey;
+        this.credentialsId = credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setVaultUrl(@CheckForNull String vaultUrl) {
+        this.vaultUrl = StringUtils.trimToNull(vaultUrl);
+    }
+
+    @DataBoundSetter
+    public void setVaultNamespace(@CheckForNull String vaultNamespace) {
+        this.vaultNamespace = StringUtils.trimToNull(vaultNamespace);
+    }
+
+    @DataBoundSetter
+    public void setMaskSecret(boolean maskSecret) {
+        this.maskSecret = maskSecret;
+    }
+
+    public String getPathAndKey() {
+        return pathAndKey;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    @CheckForNull
+    public String getVaultUrl() {
+        return vaultUrl;
+    }
+
+    @CheckForNull
+    public String getVaultNamespace() {
+        return vaultNamespace;
+    }
+
+    public boolean isMaskSecret() {
+        return maskSecret;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new Execution(this, context);
+    }
+
+    protected String fetchValue(String path, String key, Run<?, ?> run, TaskListener listener) {
+        VaultConfiguration localConfig = new VaultConfiguration();
+        if (vaultUrl != null) {
+            localConfig.setVaultUrl(vaultUrl);
+        }
+        if (vaultNamespace != null) {
+            localConfig.setVaultNamespace(vaultNamespace);
+        }
+        if (StringUtils.isNotBlank(credentialsId)) {
+            localConfig.setVaultCredentialId(credentialsId);
+        }
+
+        VaultConfiguration config = VaultAccessor.pullAndMergeConfiguration(run, localConfig);
+
+        if (StringUtils.isBlank(config.getVaultUrl())) {
+            throw new VaultPluginException(
+                "vaultUrl is not configured - set it inline or via global Vault configuration");
+        }
+
+        VaultCredential credential = config.getVaultCredential();
+        if (credential == null) {
+            credential = VaultAccessor.retrieveVaultCredentials(run, config);
+        }
+
+        VaultConfig vaultConfig = config.getVaultConfig();
+        VaultAccessor accessor = new VaultAccessor(vaultConfig, credential);
+        accessor.setConfig(vaultConfig);
+        accessor.setCredential(credential);
+        accessor.setMaxRetries(config.getMaxRetries());
+        accessor.setRetryIntervalMilliseconds(config.getRetryIntervalMilliseconds());
+        accessor.init();
+
+        LogicalResponse response = accessor.read(path, config.getEngineVersion());
+
+        if (VaultAccessor.responseHasErrors(config, listener.getLogger(), path, response)) {
+            return "";
+        }
+
+        Map<String, String> data = response.getData();
+        String value = data != null ? data.get(key) : null;
+
+        if (StringUtils.isBlank(value)) {
+            if (config.getFailIfNotFound()) {
+                throw new VaultPluginException(
+                    "Key '" + key + "' not found at Vault path '" + path + "'");
+            }
+            return "";
+        }
+
+        return value;
+    }
+
+    static class Execution extends SynchronousNonBlockingStepExecution<String> {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        private final transient VaultCredentialsStep step;
+
+        Execution(VaultCredentialsStep step, StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected String run() throws Exception {
+            String pathAndKey = step.pathAndKey;
+            int lastSlash = pathAndKey.lastIndexOf('/');
+            if (lastSlash <= 0 || lastSlash == pathAndKey.length() - 1) {
+                throw new VaultPluginException(
+                    "pathAndKey must be in 'path/to/secret/keyName' format, got: " + pathAndKey);
+            }
+            String path = pathAndKey.substring(0, lastSlash);
+            String key = pathAndKey.substring(lastSlash + 1);
+
+            Run<?, ?> run = getContext().get(Run.class);
+            TaskListener listener = getContext().get(TaskListener.class);
+
+            String value = step.fetchValue(path, key, run, listener);
+
+            if (step.maskSecret && StringUtils.isNotBlank(value)) {
+                VaultMaskedValuesAction action = run.getAction(VaultMaskedValuesAction.class);
+                if (action != null) {
+                    action.add(value);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Set.of(Run.class, TaskListener.class);
+        }
+
+        @Override
+        public boolean takesImplicitBlockArgument() {
+            return false;
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "vaultCredentials";
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Fetch a Vault KV secret value";
+        }
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/VaultCredentialsStep.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultCredentialsStep.java
@@ -26,13 +26,13 @@ import org.kohsuke.stapler.DataBoundSetter;
  * Pipeline step that fetches a single value from a Vault KV secret and returns it as a String.
  * Designed for use inside Declarative Pipeline {@code environment {}} blocks.
  *
- * <p>The first argument combines the KV path and field name: the last segment after the final
- * {@code /} is used as the field key, and everything before it is the secret path.
+ * <p>The {@code path} parameter combines the KV path and field name: the last segment after the
+ * final {@code /} is used as the field key, and everything before it is the secret path.
  *
  * <pre>
  * environment {
- *     DB_HOST = vaultCredentials('secret/myapp/db/host', 'vault-approle')
- *     DB_PASS = vaultCredentials('secret/myapp/db/password', 'vault-approle',
+ *     DB_HOST = vaultCredentials(path: 'secret/myapp/db/host', credentialsId: 'vault-approle')
+ *     DB_PASS = vaultCredentials(path: 'secret/myapp/db/password', credentialsId: 'vault-approle',
  *                   vaultUrl: 'https://vault:8200', vaultNamespace: 'prod')
  * }
  * </pre>
@@ -42,15 +42,15 @@ import org.kohsuke.stapler.DataBoundSetter;
  */
 public class VaultCredentialsStep extends Step {
 
-    private final String pathAndKey;
+    private final String path;
     private final String credentialsId;
     private String vaultUrl;
     private String vaultNamespace;
     private boolean maskSecret = true;
 
     @DataBoundConstructor
-    public VaultCredentialsStep(@NonNull String pathAndKey, @NonNull String credentialsId) {
-        this.pathAndKey = pathAndKey;
+    public VaultCredentialsStep(@NonNull String path, @NonNull String credentialsId) {
+        this.path = path;
         this.credentialsId = credentialsId;
     }
 
@@ -69,8 +69,8 @@ public class VaultCredentialsStep extends Step {
         this.maskSecret = maskSecret;
     }
 
-    public String getPathAndKey() {
-        return pathAndKey;
+    public String getPath() {
+        return path;
     }
 
     public String getCredentialsId() {
@@ -162,14 +162,13 @@ public class VaultCredentialsStep extends Step {
 
         @Override
         protected String run() throws Exception {
-            String pathAndKey = step.pathAndKey;
-            int lastSlash = pathAndKey.lastIndexOf('/');
-            if (lastSlash <= 0 || lastSlash == pathAndKey.length() - 1) {
+            int lastSlash = step.path.lastIndexOf('/');
+            if (lastSlash <= 0 || lastSlash == step.path.length() - 1) {
                 throw new VaultPluginException(
-                    "pathAndKey must be in 'path/to/secret/keyName' format, got: " + pathAndKey);
+                    "path must be in 'path/to/secret/keyName' format, got: " + step.path);
             }
-            String path = pathAndKey.substring(0, lastSlash);
-            String key = pathAndKey.substring(lastSlash + 1);
+            String path = step.path.substring(0, lastSlash);
+            String key = step.path.substring(lastSlash + 1);
 
             Run<?, ?> run = getContext().get(Run.class);
             TaskListener listener = getContext().get(TaskListener.class);
@@ -178,9 +177,11 @@ public class VaultCredentialsStep extends Step {
 
             if (step.maskSecret && StringUtils.isNotBlank(value)) {
                 VaultMaskedValuesAction action = run.getAction(VaultMaskedValuesAction.class);
-                if (action != null) {
-                    action.add(value);
+                if (action == null) {
+                    action = new VaultMaskedValuesAction();
+                    run.addOrReplaceAction(action);
                 }
+                action.add(value);
             }
 
             return value;

--- a/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesAction.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesAction.java
@@ -1,0 +1,41 @@
+package com.datapipe.jenkins.vault;
+
+import hudson.model.Action;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Per-build action that accumulates secret values registered by {@link VaultCredentialsStep}
+ * for console log masking. Values are appended as each step call resolves them, and are picked up
+ * lazily by {@link VaultMaskedValuesFilter} which holds a reference to the same list.
+ */
+@Restricted(NoExternalUse.class)
+public final class VaultMaskedValuesAction implements Action {
+
+    private final List<String> values = new CopyOnWriteArrayList<>();
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    public void add(String value) {
+        values.add(value);
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+}

--- a/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesFilter.java
@@ -1,36 +1,49 @@
 package com.datapipe.jenkins.vault;
 
 import com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.console.ConsoleLogFilter;
+import hudson.model.Queue;
 import hudson.model.Run;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Serial;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Global console log filter that registers a {@link VaultMaskedValuesAction} on every build and
- * wraps the console output with a {@link MaskingConsoleLogFilter} backed by that action's mutable
- * value list.
+ * Pipeline-compatible console log decorator that masks secret values registered by
+ * {@link VaultCredentialsStep} in subsequent console output.
  *
- * <p>Because {@link MaskingConsoleLogFilter} evaluates the pattern lazily, values added later by
- * {@link VaultCredentialsStep} are automatically masked in subsequent console output.
+ * <p>As a {@link TaskListenerDecorator.Factory}, this is invoked once per Pipeline build to
+ * produce a decorator applied to every step's output stream. It ensures a
+ * {@link VaultMaskedValuesAction} is present on the run so that values added later by
+ * {@link VaultCredentialsStep} are lazily picked up by {@link MaskingConsoleLogFilter}.
  */
 @Restricted(NoExternalUse.class)
 @Extension
-public final class VaultMaskedValuesFilter extends ConsoleLogFilter {
-
-    @Serial
-    private static final long serialVersionUID = 1L;
+public final class VaultMaskedValuesFilter implements TaskListenerDecorator.Factory {
 
     @Override
-    public OutputStream decorateLogger(Run run, OutputStream logger)
-            throws IOException, InterruptedException {
-        VaultMaskedValuesAction action = new VaultMaskedValuesAction();
-        run.addOrReplaceAction(action);
-        return new MaskingConsoleLogFilter(run.getCharset().name(), action.getValues())
-            .decorateLogger(run, logger);
+    public @CheckForNull TaskListenerDecorator of(@NonNull FlowExecutionOwner owner) {
+        Queue.Executable executable;
+        try {
+            executable = owner.getExecutable();
+        } catch (IOException e) {
+            return null;
+        }
+        if (!(executable instanceof Run)) {
+            return null;
+        }
+        Run<?, ?> run = (Run<?, ?>) executable;
+        VaultMaskedValuesAction action = run.getAction(VaultMaskedValuesAction.class);
+        if (action == null) {
+            action = new VaultMaskedValuesAction();
+            run.addOrReplaceAction(action);
+        }
+        return TaskListenerDecorator.fromConsoleLogFilter(
+            new MaskingConsoleLogFilter(run.getCharset().name(), action.getValues())
+        );
     }
 }

--- a/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesFilter.java
@@ -1,0 +1,36 @@
+package com.datapipe.jenkins.vault;
+
+import com.datapipe.jenkins.vault.log.MaskingConsoleLogFilter;
+import hudson.Extension;
+import hudson.console.ConsoleLogFilter;
+import hudson.model.Run;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serial;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Global console log filter that registers a {@link VaultMaskedValuesAction} on every build and
+ * wraps the console output with a {@link MaskingConsoleLogFilter} backed by that action's mutable
+ * value list.
+ *
+ * <p>Because {@link MaskingConsoleLogFilter} evaluates the pattern lazily, values added later by
+ * {@link VaultCredentialsStep} are automatically masked in subsequent console output.
+ */
+@Restricted(NoExternalUse.class)
+@Extension
+public final class VaultMaskedValuesFilter extends ConsoleLogFilter {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public OutputStream decorateLogger(Run run, OutputStream logger)
+            throws IOException, InterruptedException {
+        VaultMaskedValuesAction action = new VaultMaskedValuesAction();
+        run.addOrReplaceAction(action);
+        return new MaskingConsoleLogFilter(run.getCharset().name(), action.getValues())
+            .decorateLogger(run, logger);
+    }
+}

--- a/src/test/java/com/datapipe/jenkins/vault/VaultCredentialsStepTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultCredentialsStepTest.java
@@ -242,8 +242,8 @@ public class VaultCredentialsStepTest {
         String capturedVaultUrl;
         String capturedVaultNamespace;
 
-        TestStep(String pathAndKey, String credentialsId) {
-            super(pathAndKey, credentialsId);
+        TestStep(String path, String credentialsId) {
+            super(path, credentialsId);
             config.setVaultUrl("https://vault.test");
             config.setVaultCredentialId(credentialsId);
             config.setFailIfNotFound(true);

--- a/src/test/java/com/datapipe/jenkins/vault/VaultCredentialsStepTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultCredentialsStepTest.java
@@ -1,0 +1,289 @@
+package com.datapipe.jenkins.vault;
+
+import com.datapipe.jenkins.vault.configuration.VaultConfiguration;
+import com.datapipe.jenkins.vault.exception.VaultPluginException;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import io.github.jopenlibs.vault.rest.RestResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VaultCredentialsStepTest {
+
+    private static final String SECRET_PATH = "secret/myapp/db";
+    private static final String SECRET_KEY = "password";
+    private static final String PATH_AND_KEY = SECRET_PATH + "/" + SECRET_KEY;
+    private static final String SECRET_VALUE = "super-secret";
+    private static final String CREDENTIALS_ID = "vault-approle";
+
+    private VaultAccessor mockAccessor;
+    private Run<?, ?> run;
+    private TaskListener listener;
+
+    @Before
+    public void setUp() {
+        mockAccessor = mock(VaultAccessor.class);
+        doReturn(mockAccessor).when(mockAccessor).init();
+
+        run = mock(Run.class);
+        when(run.getParent()).thenReturn(null);
+
+        PrintStream logger = new PrintStream(new ByteArrayOutputStream());
+        listener = mock(TaskListener.class);
+        when(listener.getLogger()).thenReturn(logger);
+    }
+
+    @Test
+    public void happyPath_returnsValue() {
+        TestStep step = stepWithValue(SECRET_VALUE);
+
+        String result = step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(result, equalTo(SECRET_VALUE));
+    }
+
+    @Test
+    public void keyNotFound_throwsWhenFailIfNotFound() {
+        TestStep step = stepWithValue(null);
+        step.config.setFailIfNotFound(true);
+
+        VaultPluginException ex = assertThrows(VaultPluginException.class,
+            () -> step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener));
+        assertThat(ex.getMessage(), containsString(SECRET_KEY));
+        assertThat(ex.getMessage(), containsString(SECRET_PATH));
+    }
+
+    @Test
+    public void keyNotFound_returnsEmptyWhenSoftFailure() {
+        TestStep step = stepWithValue(null);
+        step.config.setFailIfNotFound(false);
+
+        String result = step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(result, equalTo(""));
+    }
+
+    @Test
+    public void pathNotFound_returnsEmptyWhenSoftFailure() {
+        LogicalResponse notFound = notFoundResponse();
+        TestStep step = new TestStep(PATH_AND_KEY, CREDENTIALS_ID);
+        step.config.setFailIfNotFound(false);
+        doReturn(notFound).when(mockAccessor).read(SECRET_PATH, 2);
+
+        String result = step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(result, equalTo(""));
+    }
+
+    @Test
+    public void accessDenied_alwaysThrows() {
+        LogicalResponse denied = accessDeniedResponse();
+        TestStep step = new TestStep(PATH_AND_KEY, CREDENTIALS_ID);
+        doReturn(denied).when(mockAccessor).read(SECRET_PATH, 2);
+
+        assertThrows(VaultPluginException.class,
+            () -> step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener));
+    }
+
+    @Test
+    public void vaultUrlOverride_capturedCorrectly() {
+        TestStep step = stepWithValue(SECRET_VALUE);
+        step.setVaultUrl("https://my-vault.example.com");
+
+        step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(step.capturedVaultUrl, equalTo("https://my-vault.example.com"));
+    }
+
+    @Test
+    public void vaultNamespaceOverride_capturedCorrectly() {
+        TestStep step = stepWithValue(SECRET_VALUE);
+        step.setVaultNamespace("prod");
+
+        step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(step.capturedVaultNamespace, equalTo("prod"));
+    }
+
+    @Test
+    public void maskingEnabled_addsValueToAction() throws Exception {
+        VaultMaskedValuesAction action = new VaultMaskedValuesAction();
+        when(run.getAction(VaultMaskedValuesAction.class)).thenReturn(action);
+
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        TestStep step = stepWithValue(SECRET_VALUE);
+        step.setMaskSecret(true);
+
+        VaultCredentialsStep.Execution exec = new VaultCredentialsStep.Execution(step, context);
+        String result = exec.run();
+
+        assertThat(result, equalTo(SECRET_VALUE));
+        assertThat(action.getValues(), equalTo(Collections.singletonList(SECRET_VALUE)));
+    }
+
+    @Test
+    public void maskingDisabled_doesNotAddToAction() throws Exception {
+        VaultMaskedValuesAction action = new VaultMaskedValuesAction();
+        when(run.getAction(VaultMaskedValuesAction.class)).thenReturn(action);
+
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        TestStep step = stepWithValue(SECRET_VALUE);
+        step.setMaskSecret(false);
+
+        new VaultCredentialsStep.Execution(step, context).run();
+
+        assertThat(action.getValues(), is(empty()));
+    }
+
+    @Test
+    public void splitting_lastSegmentBecomesKey() throws Exception {
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        TestStep step = stepWithValue(SECRET_VALUE);
+
+        new VaultCredentialsStep.Execution(step, context).run();
+
+        assertThat(step.capturedPath, equalTo(SECRET_PATH));
+        assertThat(step.capturedKey, equalTo(SECRET_KEY));
+    }
+
+    @Test
+    public void splitting_noSlash_throws() throws Exception {
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        TestStep step = new TestStep("noslash", CREDENTIALS_ID);
+
+        assertThrows(VaultPluginException.class,
+            () -> new VaultCredentialsStep.Execution(step, context).run());
+    }
+
+    @Test
+    public void splitting_trailingSlash_throws() throws Exception {
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        TestStep step = new TestStep("path/to/secret/", CREDENTIALS_ID);
+
+        assertThrows(VaultPluginException.class,
+            () -> new VaultCredentialsStep.Execution(step, context).run());
+    }
+
+    // --- helpers ---
+
+    private TestStep stepWithValue(String value) {
+        TestStep step = new TestStep(PATH_AND_KEY, CREDENTIALS_ID);
+        if (value != null) {
+            Map<String, String> data = new HashMap<>();
+            data.put(SECRET_KEY, value);
+            LogicalResponse response = mock(LogicalResponse.class);
+            when(response.getData()).thenReturn(data);
+            when(response.getRestResponse()).thenReturn(null);
+            doReturn(response).when(mockAccessor).read(SECRET_PATH, 2);
+        } else {
+            LogicalResponse response = mock(LogicalResponse.class);
+            when(response.getData()).thenReturn(Collections.emptyMap());
+            when(response.getRestResponse()).thenReturn(null);
+            doReturn(response).when(mockAccessor).read(SECRET_PATH, 2);
+        }
+        return step;
+    }
+
+    private LogicalResponse notFoundResponse() {
+        LogicalResponse resp = mock(LogicalResponse.class);
+        RestResponse rest = mock(RestResponse.class);
+        when(resp.getData()).thenReturn(Collections.emptyMap());
+        when(resp.getRestResponse()).thenReturn(rest);
+        when(rest.getStatus()).thenReturn(404);
+        return resp;
+    }
+
+    private LogicalResponse accessDeniedResponse() {
+        LogicalResponse resp = mock(LogicalResponse.class);
+        RestResponse rest = mock(RestResponse.class);
+        when(resp.getData()).thenReturn(Collections.emptyMap());
+        when(resp.getRestResponse()).thenReturn(rest);
+        when(rest.getStatus()).thenReturn(403);
+        return resp;
+    }
+
+    class TestStep extends VaultCredentialsStep {
+
+        final VaultConfiguration config = new VaultConfiguration();
+        String capturedPath;
+        String capturedKey;
+        String capturedVaultUrl;
+        String capturedVaultNamespace;
+
+        TestStep(String pathAndKey, String credentialsId) {
+            super(pathAndKey, credentialsId);
+            config.setVaultUrl("https://vault.test");
+            config.setVaultCredentialId(credentialsId);
+            config.setFailIfNotFound(true);
+            config.setEngineVersion(2);
+            config.fixDefaults();
+        }
+
+        @Override
+        protected String fetchValue(String path, String key, Run<?, ?> run, TaskListener listener) {
+            capturedPath = path;
+            capturedKey = key;
+            capturedVaultUrl = getVaultUrl();
+            capturedVaultNamespace = getVaultNamespace();
+
+            if (config.getVaultUrl() == null || config.getVaultUrl().isBlank()) {
+                throw new VaultPluginException("vaultUrl is not configured");
+            }
+
+            mockAccessor.setConfig(config.getVaultConfig());
+            mockAccessor.setMaxRetries(config.getMaxRetries());
+            mockAccessor.setRetryIntervalMilliseconds(config.getRetryIntervalMilliseconds());
+            mockAccessor.init();
+
+            LogicalResponse response = mockAccessor.read(path, config.getEngineVersion());
+
+            if (VaultAccessor.responseHasErrors(config, listener.getLogger(), path, response)) {
+                return "";
+            }
+
+            Map<String, String> data = response.getData();
+            String value = data != null ? data.get(key) : null;
+
+            if (value == null || value.isBlank()) {
+                if (config.getFailIfNotFound()) {
+                    throw new VaultPluginException(
+                        "Key '" + key + "' not found at Vault path '" + path + "'");
+                }
+                return "";
+            }
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Resolves #71.

Adds a `vaultCredentials()` Pipeline step designed for use in Declarative Pipeline `environment {}` blocks. The step fetches a single KV secret value from Vault and returns it as a `String`.

## Usage

```groovy
environment {
    DB_HOST = vaultCredentials(path: 'secret/myapp/db/host', credentialsId: 'vault-approle')
    DB_PASS = vaultCredentials(path: 'secret/myapp/db/password', credentialsId: 'vault-approle',
                  vaultUrl: 'https://vault:8200', vaultNamespace: 'prod')
    DB_PORT = vaultCredentials(path: 'secret/myapp/db/port', credentialsId: 'vault-approle',
                  maskSecret: false)
}
```

## Parameters

| Parameter | Required | Default | Description |
|-----------|----------|---------|-------------|
| `path` | yes | - | Combined KV path and field name - last segment after `/` is the field key |
| `credentialsId` | yes | - | ID of the Vault credential |
| `vaultUrl` | no | global config | Override Vault URL for this call |
| `vaultNamespace` | no | global config | Override Vault namespace for this call |
| `maskSecret` | no | `true` | Register the resolved value for automatic console log masking |

## Implementation notes

- Inherits global Vault configuration via `VaultAccessor.pullAndMergeConfiguration()`, same as `withVault()` and `VaultBuildWrapper`
- Console masking uses `TaskListenerDecorator.Factory` (`workflow-api`) - the Pipeline-native extension point applied per step, rather than `ConsoleLogFilter` which is only invoked for `AbstractBuild` (freestyle) builds
- `VaultMaskedValuesAction` accumulates masked values on the `Run` via a `CopyOnWriteArrayList`; `MaskingConsoleLogFilter` picks up additions lazily so values added by `environment {}` are masked in all subsequent stage output

## Test plan

- [x] Unit tests: `VaultCredentialsStepTest` - 12 tests (happy path, path/key splitting, key not found, masking on/off, URL/namespace override, access denied, invalid format)
- [x] Checkstyle: 0 violations
- [x] SpotBugs: 0 errors
- [x] E2E: tested against Jenkins 2.479 + OpenBao - secrets fetched and masked correctly