### PR TITLE
Bump vault-java-driver to 6.2.2 to fix TLS 1.3 regression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>io.github.jopenlibs</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>6.2.0</version>
+      <version>6.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## What

Bumps `vault-java-driver` from 6.2.0 to 6.2.2.

## Why

vault-java-driver 6.x hard-coded `SSLContext.getInstance("TLSv1.2")` for its `DISABLED_SSL_CONTEXT` (`Rest.java`) and both `SslConfig` build paths, capping TLS negotiation at 1.2. This broke connections to Vault servers that require TLS 1.3 (`protocol_version` handshake failure), e.g. when `skipSslVerification` is enabled or a custom CA cert is loaded.

6.2.2 replaces these with `getInstance("TLSv1.3")`. A TLSv1.3 context still enables TLSv1.2, so it negotiates correctly with both TLS 1.2 and TLS 1.3 servers — the regression is fixed upstream, with no plugin-side workaround needed.

Fixes #361