### PR TITLE
Rename vaultCredentials step to vault for drop-in migration off hashicorp-vault-pipeline plugin

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesAction.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesAction.java
@@ -7,7 +7,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Per-build action that accumulates secret values registered by {@link VaultCredentialsStep}
+ * Per-build action that accumulates secret values registered by {@link VaultStep}
  * for console log masking. Values are appended as each step call resolves them, and are picked up
  * lazily by {@link VaultMaskedValuesFilter} which holds a reference to the same list.
  */

--- a/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesFilter.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultMaskedValuesFilter.java
@@ -14,12 +14,12 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Pipeline-compatible console log decorator that masks secret values registered by
- * {@link VaultCredentialsStep} in subsequent console output.
+ * {@link VaultStep} in subsequent console output.
  *
  * <p>As a {@link TaskListenerDecorator.Factory}, this is invoked once per Pipeline build to
  * produce a decorator applied to every step's output stream. It ensures a
  * {@link VaultMaskedValuesAction} is present on the run so that values added later by
- * {@link VaultCredentialsStep} are lazily picked up by {@link MaskingConsoleLogFilter}.
+ * {@link VaultStep} are lazily picked up by {@link MaskingConsoleLogFilter}.
  */
 @Restricted(NoExternalUse.class)
 @Extension

--- a/src/main/java/com/datapipe/jenkins/vault/VaultStep.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultStep.java
@@ -26,32 +26,59 @@ import org.kohsuke.stapler.DataBoundSetter;
  * Pipeline step that fetches a single value from a Vault KV secret and returns it as a String.
  * Designed for use inside Declarative Pipeline {@code environment {}} blocks.
  *
- * <p>The {@code path} parameter combines the KV path and field name: the last segment after the
- * final {@code /} is used as the field key, and everything before it is the secret path.
+ * <p>The field to read can be given two ways:
+ * <ul>
+ *     <li>explicitly via the {@code key} parameter (in which case {@code path} is used verbatim), or</li>
+ *     <li>folded into {@code path}, where the last segment after the final {@code /} is the field key
+ *     and everything before it is the secret path. This applies only when {@code key} is absent.</li>
+ * </ul>
  *
  * <pre>
  * environment {
- *     DB_HOST = vaultCredentials(path: 'secret/myapp/db/host', credentialsId: 'vault-approle')
- *     DB_PASS = vaultCredentials(path: 'secret/myapp/db/password', credentialsId: 'vault-approle',
+ *     // explicit key (drop-in compatible with the hashicorp-vault-pipeline-plugin `vault` step)
+ *     DB_USER = vault path: 'secret/myapp/db', key: 'username', engineVersion: '2'
+ *
+ *     // key folded into path
+ *     DB_HOST = vault(path: 'secret/myapp/db/host', credentialsId: 'vault-approle')
+ *     DB_PASS = vault(path: 'secret/myapp/db/password', credentialsId: 'vault-approle',
  *                   vaultUrl: 'https://vault:8200', vaultNamespace: 'prod')
  * }
  * </pre>
  *
+ * <p><b>Breaking change:</b> this step is registered under the function name {@code vault}. It
+ * supersedes the {@code vaultCredentials} step name shipped in release {@code 381.v4277b_9fa_a_380}
+ * (#367); that name is no longer registered. Pipelines that adopted {@code vaultCredentials(...)}
+ * must switch to {@code vault(...)}. Aligning on the {@code vault} name is what makes migrating off
+ * the abandoned hashicorp-vault-pipeline-plugin a drop-in (see #369).
+ *
+ * <p>When {@code credentialsId} is omitted the global Vault configuration's credential is used.
+ *
  * <p>When {@code maskSecret} is {@code true} (the default), the resolved value is registered with
  * {@link VaultMaskedValuesFilter} so it is automatically redacted from subsequent console output.
  */
-public class VaultCredentialsStep extends Step {
+public class VaultStep extends Step {
 
     private final String path;
-    private final String credentialsId;
+    private String key;
+    private String credentialsId;
     private String vaultUrl;
     private String vaultNamespace;
+    private String engineVersion;
     private boolean maskSecret = true;
 
     @DataBoundConstructor
-    public VaultCredentialsStep(@NonNull String path, @NonNull String credentialsId) {
+    public VaultStep(@NonNull String path) {
         this.path = path;
-        this.credentialsId = credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setKey(@CheckForNull String key) {
+        this.key = StringUtils.trimToNull(key);
+    }
+
+    @DataBoundSetter
+    public void setCredentialsId(@CheckForNull String credentialsId) {
+        this.credentialsId = StringUtils.trimToNull(credentialsId);
     }
 
     @DataBoundSetter
@@ -64,6 +91,16 @@ public class VaultCredentialsStep extends Step {
         this.vaultNamespace = StringUtils.trimToNull(vaultNamespace);
     }
 
+    /**
+     * Per-call KV engine version override. Declared as a String (e.g. {@code '1'} or {@code '2'}) to
+     * match the old {@code vault path: '...', engineVersion: '2'} syntax exactly, so existing
+     * pipelines bind as-is. Quote the value, as the old step required.
+     */
+    @DataBoundSetter
+    public void setEngineVersion(@CheckForNull String engineVersion) {
+        this.engineVersion = StringUtils.trimToNull(engineVersion);
+    }
+
     @DataBoundSetter
     public void setMaskSecret(boolean maskSecret) {
         this.maskSecret = maskSecret;
@@ -73,6 +110,12 @@ public class VaultCredentialsStep extends Step {
         return path;
     }
 
+    @CheckForNull
+    public String getKey() {
+        return key;
+    }
+
+    @CheckForNull
     public String getCredentialsId() {
         return credentialsId;
     }
@@ -85,6 +128,11 @@ public class VaultCredentialsStep extends Step {
     @CheckForNull
     public String getVaultNamespace() {
         return vaultNamespace;
+    }
+
+    @CheckForNull
+    public String getEngineVersion() {
+        return engineVersion;
     }
 
     public boolean isMaskSecret() {
@@ -103,6 +151,14 @@ public class VaultCredentialsStep extends Step {
         }
         if (vaultNamespace != null) {
             localConfig.setVaultNamespace(vaultNamespace);
+        }
+        if (engineVersion != null) {
+            try {
+                localConfig.setEngineVersion(Integer.valueOf(engineVersion));
+            } catch (NumberFormatException e) {
+                throw new VaultPluginException(
+                    "engineVersion must be an integer, got: " + engineVersion);
+            }
         }
         if (StringUtils.isNotBlank(credentialsId)) {
             localConfig.setVaultCredentialId(credentialsId);
@@ -153,22 +209,32 @@ public class VaultCredentialsStep extends Step {
         @Serial
         private static final long serialVersionUID = 1L;
 
-        private final transient VaultCredentialsStep step;
+        private final transient VaultStep step;
 
-        Execution(VaultCredentialsStep step, StepContext context) {
+        Execution(VaultStep step, StepContext context) {
             super(context);
             this.step = step;
         }
 
         @Override
         protected String run() throws Exception {
-            int lastSlash = step.path.lastIndexOf('/');
-            if (lastSlash <= 0 || lastSlash == step.path.length() - 1) {
-                throw new VaultPluginException(
-                    "path must be in 'path/to/secret/keyName' format, got: " + step.path);
+            String path;
+            String key;
+            if (StringUtils.isNotBlank(step.key)) {
+                // Explicit key: path is used verbatim (compatible with the old `vault` step).
+                path = step.path;
+                key = step.key;
+            } else {
+                // No explicit key: the last path segment is the field name.
+                int lastSlash = step.path.lastIndexOf('/');
+                if (lastSlash <= 0 || lastSlash == step.path.length() - 1) {
+                    throw new VaultPluginException(
+                        "path must be in 'path/to/secret/keyName' format (or supply a separate 'key'), got: "
+                            + step.path);
+                }
+                path = step.path.substring(0, lastSlash);
+                key = step.path.substring(lastSlash + 1);
             }
-            String path = step.path.substring(0, lastSlash);
-            String key = step.path.substring(lastSlash + 1);
 
             Run<?, ?> run = getContext().get(Run.class);
             TaskListener listener = getContext().get(TaskListener.class);
@@ -203,7 +269,7 @@ public class VaultCredentialsStep extends Step {
 
         @Override
         public String getFunctionName() {
-            return "vaultCredentials";
+            return "vault";
         }
 
         @NonNull

--- a/src/test/java/com/datapipe/jenkins/vault/VaultStepTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultStepTest.java
@@ -20,12 +20,13 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class VaultCredentialsStepTest {
+public class VaultStepTest {
 
     private static final String SECRET_PATH = "secret/myapp/db";
     private static final String SECRET_KEY = "password";
@@ -123,6 +124,60 @@ public class VaultCredentialsStepTest {
     }
 
     @Test
+    public void engineVersionOverride_appliedToRead() {
+        // Mixed KV v1/v2: a per-call engineVersion overrides the global default.
+        TestStep step = new TestStep(PATH_AND_KEY, CREDENTIALS_ID);
+        step.setEngineVersion("1");
+        Map<String, String> data = new HashMap<>();
+        data.put(SECRET_KEY, SECRET_VALUE);
+        LogicalResponse response = mock(LogicalResponse.class);
+        when(response.getData()).thenReturn(data);
+        when(response.getRestResponse()).thenReturn(null);
+        doReturn(response).when(mockAccessor).read(SECRET_PATH, 1);
+
+        String result = step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(result, equalTo(SECRET_VALUE));
+        assertThat(step.capturedEngineVersion, equalTo(1));
+    }
+
+    @Test
+    public void engineVersionDefault_usesGlobalWhenUnset() {
+        TestStep step = stepWithValue(SECRET_VALUE);
+
+        step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(step.getEngineVersion(), is(nullValue()));
+        assertThat(step.capturedEngineVersion, equalTo(2));
+    }
+
+    @Test
+    public void engineVersionNonNumeric_throws() {
+        TestStep step = new TestStep(PATH_AND_KEY, CREDENTIALS_ID);
+        step.setEngineVersion("two");
+
+        assertThrows(VaultPluginException.class,
+            () -> step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener));
+    }
+
+    @Test
+    public void credentialsIdOptional_blankStillResolves() {
+        // The old `vault` step falls back to the global credential when none is given.
+        TestStep step = new TestStep(PATH_AND_KEY, null);
+        Map<String, String> data = new HashMap<>();
+        data.put(SECRET_KEY, SECRET_VALUE);
+        LogicalResponse response = mock(LogicalResponse.class);
+        when(response.getData()).thenReturn(data);
+        when(response.getRestResponse()).thenReturn(null);
+        doReturn(response).when(mockAccessor).read(SECRET_PATH, 2);
+
+        String result = step.fetchValue(SECRET_PATH, SECRET_KEY, run, listener);
+
+        assertThat(step.getCredentialsId(), is(nullValue()));
+        assertThat(result, equalTo(SECRET_VALUE));
+    }
+
+    @Test
     public void maskingEnabled_addsValueToAction() throws Exception {
         VaultMaskedValuesAction action = new VaultMaskedValuesAction();
         when(run.getAction(VaultMaskedValuesAction.class)).thenReturn(action);
@@ -134,7 +189,7 @@ public class VaultCredentialsStepTest {
         TestStep step = stepWithValue(SECRET_VALUE);
         step.setMaskSecret(true);
 
-        VaultCredentialsStep.Execution exec = new VaultCredentialsStep.Execution(step, context);
+        VaultStep.Execution exec = new VaultStep.Execution(step, context);
         String result = exec.run();
 
         assertThat(result, equalTo(SECRET_VALUE));
@@ -153,7 +208,7 @@ public class VaultCredentialsStepTest {
         TestStep step = stepWithValue(SECRET_VALUE);
         step.setMaskSecret(false);
 
-        new VaultCredentialsStep.Execution(step, context).run();
+        new VaultStep.Execution(step, context).run();
 
         assertThat(action.getValues(), is(empty()));
     }
@@ -166,10 +221,45 @@ public class VaultCredentialsStepTest {
 
         TestStep step = stepWithValue(SECRET_VALUE);
 
-        new VaultCredentialsStep.Execution(step, context).run();
+        new VaultStep.Execution(step, context).run();
 
         assertThat(step.capturedPath, equalTo(SECRET_PATH));
         assertThat(step.capturedKey, equalTo(SECRET_KEY));
+    }
+
+    @Test
+    public void explicitKey_pathUsedVerbatim() throws Exception {
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        // path is NOT split when an explicit key is supplied.
+        TestStep step = new TestStep(SECRET_PATH, CREDENTIALS_ID);
+        step.setKey(SECRET_KEY);
+        stubRead(SECRET_PATH, SECRET_KEY, SECRET_VALUE);
+
+        new VaultStep.Execution(step, context).run();
+
+        assertThat(step.capturedPath, equalTo(SECRET_PATH));
+        assertThat(step.capturedKey, equalTo(SECRET_KEY));
+    }
+
+    @Test
+    public void explicitKey_singleSegmentPathDoesNotThrow() throws Exception {
+        StepContext context = mock(StepContext.class);
+        when(context.get(Run.class)).thenReturn(run);
+        when(context.get(TaskListener.class)).thenReturn(listener);
+
+        // Old-style single-segment path (e.g. `vault path: 'secrets', key: 'username'`).
+        TestStep step = new TestStep("secrets", CREDENTIALS_ID);
+        step.setKey("username");
+        stubRead("secrets", "username", SECRET_VALUE);
+
+        String result = new VaultStep.Execution(step, context).run();
+
+        assertThat(step.capturedPath, equalTo("secrets"));
+        assertThat(step.capturedKey, equalTo("username"));
+        assertThat(result, equalTo(SECRET_VALUE));
     }
 
     @Test
@@ -181,7 +271,7 @@ public class VaultCredentialsStepTest {
         TestStep step = new TestStep("noslash", CREDENTIALS_ID);
 
         assertThrows(VaultPluginException.class,
-            () -> new VaultCredentialsStep.Execution(step, context).run());
+            () -> new VaultStep.Execution(step, context).run());
     }
 
     @Test
@@ -193,27 +283,33 @@ public class VaultCredentialsStepTest {
         TestStep step = new TestStep("path/to/secret/", CREDENTIALS_ID);
 
         assertThrows(VaultPluginException.class,
-            () -> new VaultCredentialsStep.Execution(step, context).run());
+            () -> new VaultStep.Execution(step, context).run());
     }
 
     // --- helpers ---
 
     private TestStep stepWithValue(String value) {
         TestStep step = new TestStep(PATH_AND_KEY, CREDENTIALS_ID);
+        LogicalResponse response = mock(LogicalResponse.class);
         if (value != null) {
             Map<String, String> data = new HashMap<>();
             data.put(SECRET_KEY, value);
-            LogicalResponse response = mock(LogicalResponse.class);
             when(response.getData()).thenReturn(data);
-            when(response.getRestResponse()).thenReturn(null);
-            doReturn(response).when(mockAccessor).read(SECRET_PATH, 2);
         } else {
-            LogicalResponse response = mock(LogicalResponse.class);
             when(response.getData()).thenReturn(Collections.emptyMap());
-            when(response.getRestResponse()).thenReturn(null);
-            doReturn(response).when(mockAccessor).read(SECRET_PATH, 2);
         }
+        when(response.getRestResponse()).thenReturn(null);
+        doReturn(response).when(mockAccessor).read(SECRET_PATH, 2);
         return step;
+    }
+
+    private void stubRead(String path, String key, String value) {
+        Map<String, String> data = new HashMap<>();
+        data.put(key, value);
+        LogicalResponse response = mock(LogicalResponse.class);
+        when(response.getData()).thenReturn(data);
+        when(response.getRestResponse()).thenReturn(null);
+        doReturn(response).when(mockAccessor).read(path, 2);
     }
 
     private LogicalResponse notFoundResponse() {
@@ -234,16 +330,18 @@ public class VaultCredentialsStepTest {
         return resp;
     }
 
-    class TestStep extends VaultCredentialsStep {
+    class TestStep extends VaultStep {
 
         final VaultConfiguration config = new VaultConfiguration();
         String capturedPath;
         String capturedKey;
         String capturedVaultUrl;
         String capturedVaultNamespace;
+        Integer capturedEngineVersion;
 
         TestStep(String path, String credentialsId) {
-            super(path, credentialsId);
+            super(path);
+            setCredentialsId(credentialsId);
             config.setVaultUrl("https://vault.test");
             config.setVaultCredentialId(credentialsId);
             config.setFailIfNotFound(true);
@@ -257,6 +355,17 @@ public class VaultCredentialsStepTest {
             capturedKey = key;
             capturedVaultUrl = getVaultUrl();
             capturedVaultNamespace = getVaultNamespace();
+
+            // Mirror the real per-call engineVersion override against the local config.
+            if (getEngineVersion() != null) {
+                try {
+                    config.setEngineVersion(Integer.valueOf(getEngineVersion()));
+                } catch (NumberFormatException e) {
+                    throw new VaultPluginException(
+                        "engineVersion must be an integer, got: " + getEngineVersion());
+                }
+            }
+            capturedEngineVersion = config.getEngineVersion();
 
             if (config.getVaultUrl() == null || config.getVaultUrl().isBlank()) {
                 throw new VaultPluginException("vaultUrl is not configured");


### PR DESCRIPTION
  ### What this does
  
  Resolves #369.

  Reworks the `vaultCredentials` Pipeline step added in #367 so that teams on the now-abandoned
  [hashicorp-vault-pipeline-plugin](https://github.com/jenkinsci/hashicorp-vault-pipeline-plugin) can migrate by upgrading this plugin and deleting the old one — rather than rewriting their pipelines. 
  Concretely:

  - ⚠️ Breaking change: **Rename the step function name `vaultCredentials` → `vault`**, matching the
    old plugin's `vault` step so existing `environment {}` usages keep working. Please, let me know if you want to keep both names and mark `vaultCredentials` as deprecated.
  - **Optional `key` parameter.** When `key` is given, `path` is used verbatim; otherwise the field
    name is taken from the last `/`-segment of `path`. Single-segment paths like `path: 'secrets'` now work too.
  - **Optional `credentialsId`.** Falls back to the global Vault configuration when omitted.
  - **Per-call `engineVersion` override** (quoted String, e.g. `'2'`), for controllers talking to
    mounts of mixed KV v1/v2. Matches the `vault` step's behavior exactly.

###  Testing done

  - Unit tests (VaultStepTest, 18 cases) covering: path/key splitting, explicit key, single-segment
  path, optional credentialsId → global fallback, per-call engineVersion (incl. non-numeric → error).
  - I also did some end-to-end tests against a real HashiCorp Vault + Jenkins in Docker: I seeded 2 entries with KV v1 and v2, put global config engineVersion = 2, and run some tests in a pipeline (click on `Pipeline code` collapsible section to see the code).
<details>
<summary> Pipeline code</summary>

```bash
# vault setup
set -eux

# KV v1 secret at secret/myapp
vault secrets disable secret 2>/dev/null || true
vault secrets enable -path=secret -version=1 kv
vault kv put secret/myapp username=alice password=s3cr3t

# KV v2 secret at kv2/app
vault secrets enable -path=kv2 -version=2 kv
vault kv put kv2/app api_key=abcdef-0123456789 env=production

echo "[vault-init] seeded test secrets"
```
Pipeline job:
```groovy
pipeline {
    agent any
    environment {
        // KV v1 mount: needs engineVersion: '1' to override the v2 global default.
        // No credentialsId given -> falls back to the global vault-token credential.
        APP_USER = vault(path: 'secret/myapp', key: 'username', engineVersion: '1')
        APP_PASS = vault(path: 'secret/myapp', key: 'password', engineVersion: '1')
        // KV v2 mount: uses the global engineVersion (2); explicit key parameter.
        API_KEY  = vault(path: 'kv2/app', key: 'api_key')
        // Folded path (no key): the last segment 'env' is the field name.
        API_ENV  = vault(path: 'kv2/app/env')
    }
    stages {
        stage('Assert environment block') {
            steps {
                script {
                    assert env.APP_USER == 'alice'              : "APP_USER=${env.APP_USER}"
                    assert env.APP_PASS == 's3cr3t'             : "APP_PASS length=${env.APP_PASS?.length()}"
                    assert env.API_KEY  == 'abcdef-0123456789'  : "API_KEY=${env.API_KEY}"
                    assert env.API_ENV  == 'production'         : "API_ENV=${env.API_ENV}"
                    echo 'OK: environment-block assertions passed'
                }
            }
        }
        stage('Assert inline + folded + override') {
            steps {
                script {
                    // Folded path, inline (not in environment block), KV v2.
                    def folded = vault(path: 'kv2/app/api_key')
                    assert folded == 'abcdef-0123456789' : "folded inline=${folded}"

                    // Per-call engineVersion override (string), KV v1.
                    def pw = vault(path: 'secret/myapp', key: 'password', engineVersion: '1')
                    assert pw == 's3cr3t' : "override inline length=${pw?.length()}"

                    echo 'OK: inline assertions passed'
                }
            }
        }
    }
    post {
        success { echo 'VAULT-STEP-E2E: PASS' }
        failure { echo 'VAULT-STEP-E2E: FAIL' }
    }
}
```
</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
