### PR TITLE
fix: resolve AWS region dynamically for STS endpoint in AWS IAM auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>7</source>
+          <target>7</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/src/main/java/com/datapipe/jenkins/vault/AwsHelper.java
+++ b/src/main/java/com/datapipe/jenkins/vault/AwsHelper.java
@@ -1,10 +1,12 @@
 package com.datapipe.jenkins.vault;
 
 import com.amazonaws.DefaultRequest;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWS4Signer;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.HttpMethodName;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.amazonaws.util.RuntimeHttpUtils;
 import com.datapipe.jenkins.vault.exception.VaultPluginException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -66,7 +68,7 @@ public class AwsHelper {
         public final String encodedUrl;
 
         private static final String data = "Action=GetCallerIdentity&Version=2011-06-15";
-        private static final String endpoint = "https://sts.amazonaws.com";
+
 
         EncodedIdentityRequest(@CheckForNull AWSCredentials credentials, @CheckForNull String serverIdValue) throws IOException, URISyntaxException {
             LOGGER.fine("Creating GetCallerIdentity request");
@@ -77,7 +79,16 @@ public class AwsHelper {
             }
             request.setContent(new ByteArrayInputStream(this.data.getBytes(StandardCharsets.UTF_8)));
             request.setHttpMethod(HttpMethodName.POST);
-            request.setEndpoint(new URI(this.endpoint));
+            String region;
+            try {
+                region = new DefaultAwsRegionProviderChain().getRegion();
+                LOGGER.fine("Resolved AWS region: " + region);
+            } catch (SdkClientException e) {
+                region = "us-east-1";
+                LOGGER.warning("Could not resolve AWS region, falling back to us-east-1: " + e.getMessage());
+            }
+            String stsEndpoint = "https://sts." + region + ".amazonaws.com";
+            request.setEndpoint(new URI(stsEndpoint));
 
             if (credentials == null) {
                 LOGGER.fine("Acquiring AWS credentials");
@@ -88,6 +99,7 @@ public class AwsHelper {
             LOGGER.fine("Signing GetCallerIdentity request");
             final AWS4Signer aws4Signer = new AWS4Signer();
             aws4Signer.setServiceName(request.getServiceName());
+            aws4Signer.setRegionName(region);
             aws4Signer.sign(request, credentials);
 
             final Base64.Encoder encoder = Base64.getEncoder();

--- a/src/test/java/com/datapipe/jenkins/vault/AwsHelperTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/AwsHelperTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
-
 import hudson.Util;
 import io.github.jopenlibs.vault.VaultException;
 import io.github.jopenlibs.vault.api.Auth;
@@ -20,11 +19,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.After;
-import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/datapipe/jenkins/vault/AwsHelperTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/AwsHelperTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+
 import hudson.Util;
 import io.github.jopenlibs.vault.VaultException;
 import io.github.jopenlibs.vault.api.Auth;
@@ -22,6 +23,8 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.After;
+import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,6 +44,16 @@ public class AwsHelperTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUpRegion() {
+        System.setProperty("aws.region", "us-east-1");
+    }
+
+    @After
+    public void tearDownRegion() {
+        System.clearProperty("aws.region");
+    }
 
     @Test
     public void testGetTokenBasicDefaults() throws VaultException {
@@ -90,7 +103,7 @@ public class AwsHelperTest {
         final Base64.Decoder decoder = Base64.getDecoder();
 
         final String decodedUrl = new String(decoder.decode(urlArg.getValue()), charset);
-        assertThat(decodedUrl, is("https://sts.amazonaws.com/"));
+        assertThat(decodedUrl, is("https://sts.us-east-1.amazonaws.com/"));
 
         final String decodedBody = new String(decoder.decode(bodyArg.getValue()), charset);
         assertThat(decodedBody, is("Action=GetCallerIdentity&Version=2011-06-15"));
@@ -117,7 +130,7 @@ public class AwsHelperTest {
             assertThat(valuesArray.size(), is(1));
             headersMap.put(member.getName(), valuesArray.get(0).asString());
         }
-        assertThat(headersMap.get("Host"), is("sts.amazonaws.com"));
+        assertThat(headersMap.get("Host"), is("sts.us-east-1.amazonaws.com"));
         assertThat(headersMap.get("Content-Type"), is("application/x-www-form-urlencoded; charset=utf-8"));
         if (credentials instanceof AWSSessionCredentials sessionCreds) {
             assertThat(headersMap.get("X-Amz-Security-Token"), is(sessionCreds.getSessionToken()));


### PR DESCRIPTION
The STS endpoint in `EncodedIdentityRequest` was hardcoded to
`https://sts.amazonaws.com`, and `AWS4Signer.sign()` was called without
`setRegionName()`. The signer derives the region from the endpoint URI,
but the global STS endpoint has no regional component, so it falls back
to `us-east-1` regardless of the actual instance region or any environment
configuration (`AWS_REGION`, `AWS_DEFAULT_REGION`, `~/.aws/config`).

This causes authentication failures on EC2 instances in any region other
than `us-east-1` when `use_sts_region_from_client` is enabled on the
Vault AWS auth method.

## Fix

Use `DefaultAwsRegionProviderChain` to resolve the region at runtime,
construct a regional STS endpoint (`https://sts.<region>.amazonaws.com`),
and pass the region explicitly to `AWS4Signer` via `setRegionName()`.
`DefaultAwsRegionProviderChain` follows the standard AWS SDK resolution
chain (environment variables, `~/.aws/config`, instance metadata).

No new dependencies required: `DefaultAwsRegionProviderChain` is already
available from `aws-java-sdk-core`, which is a transitive dependency.

Closes #371

### Testing done

Tested manually on an EC2 instance in `eu-south-1` running Jenkins with
the `hashicorp-vault-plugin` against a Vault Enterprise 2.0.3 instance
configured with AWS IAM auth (`auth_type=iam`,
`use_sts_region_from_client=true`, no `sts_endpoint` or `sts_region` set
on the Vault side).

Before this fix, the signed `GetCallerIdentity` request was always scoped
to `us-east-1` regardless of environment configuration (`AWS_REGION`,
`AWS_DEFAULT_REGION`, `~/.aws/config` all set to `eu-south-1`, confirmed
present in the Jenkins process environment via `/proc/<pid>/environ`).
Vault rejected the login with:

    error making upstream request: error making request:
    POST https://sts.us-east-1.amazonaws.com// giving up after 3 attempt(s):
    context canceled

After applying this fix, `DefaultAwsRegionProviderChain` correctly
resolves `eu-south-1` from the EC2 instance metadata, the STS endpoint
becomes `https://sts.eu-south-1.amazonaws.com`, the SigV4 signature is
scoped to the correct region, and authentication succeeds.

Existing unit tests in `AwsHelperTest` have been updated to pin
`aws.region=us-east-1` via system property in `@Before`/`@After` to
ensure deterministic behavior regardless of where the CI runner is
located, and assertions updated to match the new regional endpoint format.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed