### PR TITLE
Percent-encode URI-illegal characters in Vault paths

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
+++ b/src/main/java/com/datapipe/jenkins/vault/VaultAccessor.java
@@ -319,9 +319,18 @@ public class VaultAccessor implements Serializable {
         return configuration;
     }
 
+    // Characters java.net.URI rejects in a path (space, quotes, brackets, etc.) or misparses
+    // ('#' and '?' start the fragment/query and would silently truncate the path). '%' is
+    // deliberately absent so paths that are already percent-encoded keep working; a literal
+    // '%' in a secret name must be written as '%25'.
+    private static final String URI_ILLEGAL_PATH_CHARS = " \"<>[]{}|\\^`#?";
+
     /**
-     * Normalize user-supplied Vault paths so we don't send leading or duplicate slashes to Vault.
-     * Leading slashes cause requests like "/v1//path" which Vault replies to with HTTP 301 for KV v1.
+     * Normalize user-supplied Vault paths so we don't send leading or duplicate slashes to Vault,
+     * and percent-encode characters java.net.URI cannot parse in a path (Vault decodes them
+     * server-side). Leading slashes cause requests like "/v1//path" which Vault replies to with
+     * HTTP 301 for KV v1; a literal space (or quote, bracket, etc.) makes java.net.URI throw
+     * URISyntaxException.
      */
     static String normalizePath(String path) {
         if (StringUtils.isBlank(path)) {
@@ -331,12 +340,21 @@ public class VaultAccessor implements Serializable {
         // remove any leading slashes
         String cleaned = StringUtils.stripStart(path, "/");
 
-        // fast-path: nothing to do in the common case
-        if (!cleaned.contains("//")) {
-            return cleaned;
+        // collapse duplicate separators
+        if (cleaned.contains("//")) {
+            cleaned = cleaned.replaceAll("/{2,}", "/");
         }
 
-        // collapse duplicate separators
-        return cleaned.replaceAll("/{2,}", "/");
+        // percent-encode what java.net.URI cannot parse; Vault decodes it back
+        StringBuilder sb = new StringBuilder(cleaned.length());
+        for (int i = 0; i < cleaned.length(); i++) {
+            char c = cleaned.charAt(i);
+            if (c < 0x20 || c == 0x7F || URI_ILLEGAL_PATH_CHARS.indexOf(c) >= 0) {
+                sb.append(String.format("%%%02X", (int) c));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultAccessorTest.java
@@ -23,6 +23,18 @@ public class VaultAccessorTest {
     }
 
     @Test
+    public void normalizePathEscapesUriIllegalCharacters() {
+        assertEquals("team/My%20Secret%20Name", VaultAccessor.normalizePath("team/My Secret Name"));
+        // characters java.net.URI rejects in a path
+        assertEquals("a%22b%3Cc%3Ed%5Be%5Df%7Bg%7Dh%7Ci%5Cj%5Ek%60l",
+            VaultAccessor.normalizePath("a\"b<c>d[e]f{g}h|i\\j^k`l"));
+        // '#' and '?' would silently truncate the path as fragment/query markers
+        assertEquals("team/a%23b%3Fc", VaultAccessor.normalizePath("team/a#b?c"));
+        // already percent-encoded paths are left untouched
+        assertEquals("team/My%20Secret%20Name", VaultAccessor.normalizePath("team/My%20Secret%20Name"));
+    }
+
+    @Test
     public void testGeneratePolicies() {
         EnvVars envVars = mock(EnvVars.class);
         when(envVars.get("JOB_NAME")).thenReturn("job1");


### PR DESCRIPTION
## Problem

Reading a secret whose path contains a space fails before any request is sent:

```
java.net.URISyntaxException: Illegal character in path at index 42: https://vault.example.com/v1/team/My Secret Name
    at io.github.jopenlibs.vault.rest.Rest.buildRequest(Rest.java:494)
    ...
com.datapipe.jenkins.vault.exception.VaultPluginException: could not read from vault: ... at path: team/My Secret Name
    at com.datapipe.jenkins.vault.VaultAccessor.read(VaultAccessor.java)
```

Such paths are easy to create — the Vault UI happily accepts human-readable secret names with spaces. The vault-java-driver concatenates the path into the URL and calls `new URI(String)`, which strictly rejects a literal space (and `" < > [ ] { } | \ ^ ` `` ` ``) instead of encoding it. `#` and `?` don't throw but are parsed as fragment/query markers, silently truncating the path.

## Fix

Extend `VaultAccessor.normalizePath()` (introduced in #359) to percent-encode the characters `java.net.URI` cannot parse in a path. Vault decodes them server-side, so the same secret is read.

`%` is deliberately **not** encoded: users hitting this error today work around it by pre-encoding the path (e.g. `My%20Secret%20Name`), and encoding `%` would break them. The trade-off is that a literal `%` in a secret name still has to be written as `%25`; this is documented on the constant.

## Testing

`VaultAccessorTest#normalizePathEscapesUriIllegalCharacters` covers spaces, the URI-rejected set, `#`/`?` truncation, and verifies already-encoded paths pass through unchanged.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
